### PR TITLE
Fix error with not well formed Auth header

### DIFF
--- a/src/Amadeus/Client/Session/Handler/SoapHeader2.php
+++ b/src/Amadeus/Client/Session/Handler/SoapHeader2.php
@@ -40,6 +40,11 @@ class SoapHeader2 extends Base
     const CORE_WS_V2_SESSION_NS = 'http://xml.amadeus.com/ws/2009/01/WBS_Session-2.0.xsd';
 
     /**
+     * Node for Session
+     */
+    const NODENAME_SESSION = "Session";
+
+    /**
      * Node for Session ID
      */
     const NODENAME_SESSIONID = "SessionId";
@@ -77,7 +82,7 @@ class SoapHeader2 extends Base
             );
 
             $this->getSoapClient()->__setSoapHeaders(
-                new \SoapHeader(self::CORE_WS_V2_SESSION_NS, self::NODENAME_SESSIONID, $session)
+                new \SoapHeader(self::CORE_WS_V2_SESSION_NS, self::NODENAME_SESSION, $session)
             );
         }
     }

--- a/src/Amadeus/Client/Struct/HeaderV2/Session.php
+++ b/src/Amadeus/Client/Struct/HeaderV2/Session.php
@@ -33,15 +33,15 @@ class Session
     /**
      * @var string
      */
-    public $sessionId;
+    public $SessionId;
     /**
      * @var int
      */
-    public $sequenceNumber;
+    public $SequenceNumber;
     /**
      * @var string
      */
-    public $securityToken;
+    public $SecurityToken;
 
     /**
      * @param string	$sessId
@@ -50,8 +50,8 @@ class Session
      */
     public function __construct($sessId, $seqNr, $secTok)
     {
-        $this->sessionId = $sessId;
-        $this->sequenceNumber = $seqNr;
-        $this->securityToken = $secTok;
+        $this->SessionId = $sessId;
+        $this->SequenceNumber = $seqNr;
+        $this->SecurityToken = $secTok;
     }
 }


### PR DESCRIPTION
Hi.

I tried to use develop branch to make some requests and faced with auth problems:

first:

    PHP Fatal error:  SOAP-ERROR: Encoding: object has no 'SessionId' property in /path/to/amadeus-ws-client/vendor/amabnl/amadeus-ws-client/src/Amadeus/Client/Session/Handler/Base.php on line 212

after fixing first one:

      SOAPFAULT while sending message Fare_MasterPricerTravelBoardSearch:  12|Presentation|soap message header incorrect code: 0 at /path/to/amadeus-ws-client/vendor/amabnl/amadeus-ws-client/src/Amadeus/Client/Session/Handler/Base.php line 212:

on any request.

After some investigations I figured out the problems. I made some changes which allows to run the code without errors.

P.S. Tests are ignores the problems, so my changes didn't influenced on its greens.