### PR TITLE
Support for multiple WSDL's

### DIFF
--- a/src/Amadeus/Client.php
+++ b/src/Amadeus/Client.php
@@ -106,6 +106,11 @@ class Client
     protected $authParams;
 
     /**
+     * @var string
+     */
+    protected $lastMessage;
+
+    /**
      * Set the session as stateful (true) or stateless (false)
      *
      * @param bool $newStateful
@@ -130,7 +135,7 @@ class Client
      */
     public function getLastRequest()
     {
-        return $this->sessionHandler->getLastRequest();
+        return $this->sessionHandler->getLastRequest($this->lastMessage);
     }
 
     /**
@@ -140,7 +145,7 @@ class Client
      */
     public function getLastResponse()
     {
-        return $this->sessionHandler->getLastResponse();
+        return $this->sessionHandler->getLastResponse($this->lastMessage);
     }
 
     /**
@@ -677,6 +682,8 @@ class Client
     protected function callMessage($messageName, $options, $messageOptions, $endSession = false)
     {
         $messageOptions = $this->makeMessageOptions($messageOptions, $endSession);
+
+        $this->lastMessage = $messageName;
 
         $sendResult = $this->sessionHandler->sendMessage(
             $messageName,

--- a/src/Amadeus/Client/Params/SessionHandlerParams.php
+++ b/src/Amadeus/Client/Params/SessionHandlerParams.php
@@ -37,12 +37,13 @@ class SessionHandlerParams
     /**
      * Full file & path to the WSDL file to be used
      *
-     * @var string
+     * @var string[]
      */
-    public $wsdl;
+    public $wsdl = [];
 
     /**
      * Which Soap Header version to be used
+     *
      * @var string
      */
     public $soapHeaderVersion = Client::HEADER_V4;
@@ -86,6 +87,13 @@ class SessionHandlerParams
     public $overrideSoapClient;
 
     /**
+     * Override SoapClient WSDL name
+     *
+     * @var string
+     */
+    public $overrideSoapClientWsdlName;
+
+    /**
      * @param array $params
      */
     public function __construct($params = [])
@@ -119,12 +127,22 @@ class SessionHandlerParams
     /**
      * Load WSDL from config
      *
+     * Either a single WSDL location as string or a list of WSDL locations as array.
+     *
      * @param array $params
      * @return void
      */
     protected function loadWsdl($params)
     {
-        $this->wsdl = (isset($params['wsdl'])) ? $params['wsdl'] : null;
+        if (isset($params['wsdl'])) {
+            if (is_string($params['wsdl'])) {
+                $this->wsdl = [
+                    $params['wsdl']
+                ];
+            } elseif (is_array($params['wsdl'])) {
+                $this->wsdl = $params['wsdl'];
+            }
+        }
     }
 
     /**
@@ -179,6 +197,9 @@ class SessionHandlerParams
     {
         if (isset($params['overrideSoapClient']) && $params['overrideSoapClient'] instanceof \SoapClient) {
             $this->overrideSoapClient = $params['overrideSoapClient'];
+        }
+        if (isset($params['overrideSoapClientWsdlName'])) {
+            $this->overrideSoapClientWsdlName = $params['overrideSoapClientWsdlName'];
         }
     }
 

--- a/src/Amadeus/Client/Session/Handler/HandlerInterface.php
+++ b/src/Amadeus/Client/Session/Handler/HandlerInterface.php
@@ -98,14 +98,16 @@ interface HandlerInterface
     /**
      * Get the last raw XML message that was sent out
      *
+     * @param string $msgName
      * @return string|null
      */
-    public function getLastRequest();
+    public function getLastRequest($msgName);
 
     /**
      * Get the last raw XML message that was received
      *
+     * @param string $msgName
      * @return string|null
      */
-    public function getLastResponse();
+    public function getLastResponse($msgName);
 }

--- a/src/Amadeus/Client/Session/Handler/SoapHeader2.php
+++ b/src/Amadeus/Client/Session/Handler/SoapHeader2.php
@@ -23,8 +23,6 @@
 namespace Amadeus\Client\Session\Handler;
 
 use Amadeus\Client;
-use Amadeus\Client\Params\SessionHandlerParams;
-use Amadeus\Client\Struct\BaseWsMessage;
 
 /**
  * SoapHeader2: Session Handler for web service applications using Amadeus WS Soap Header v2.
@@ -70,7 +68,7 @@ class SoapHeader2 extends Base
             throw new InvalidSessionException('No active session');
         }
 
-        $this->getSoapClient()->__setSoapHeaders(null);
+        $this->getSoapClient($messageName)->__setSoapHeaders(null);
 
         if ($this->isAuthenticated === true && is_int($this->sessionData['sequenceNumber'])) {
             $this->sessionData['sequenceNumber']++;
@@ -81,7 +79,7 @@ class SoapHeader2 extends Base
                 $this->sessionData['securityToken']
             );
 
-            $this->getSoapClient()->__setSoapHeaders(
+            $this->getSoapClient($messageName)->__setSoapHeaders(
                 new \SoapHeader(self::CORE_WS_V2_SESSION_NS, self::NODENAME_SESSION, $session)
             );
         }
@@ -166,12 +164,15 @@ class SoapHeader2 extends Base
     }
 
     /**
+     * @param string $wsdlId
      * @return \SoapClient
      */
-    protected function initSoapClient()
+    protected function initSoapClient($wsdlId)
     {
+        $wsdlPath = $this->wsdlIds[$wsdlId];
+
         $client = new Client\SoapClient(
-            $this->params->wsdl,
+            $wsdlPath,
             $this->makeSoapClientOptions(),
             $this->params->logger
         );

--- a/tests/Amadeus/Client/Params/SessionHandlerParamsTest.php
+++ b/tests/Amadeus/Client/Params/SessionHandlerParamsTest.php
@@ -41,8 +41,9 @@ class SessionHandlerParamsTest extends BaseTestCase
         $this->assertNull($par->authParams);
         $this->assertNull($par->logger);
         $this->assertNull($par->overrideSoapClient);
+        $this->assertNull($par->overrideSoapClientWsdlName);
         $this->assertTrue($par->stateful);
-        $this->assertNull($par->wsdl);
+        $this->assertEmpty($par->wsdl);
         $this->assertEquals(Client::HEADER_V4,$par->soapHeaderVersion);
     }
 

--- a/tests/Amadeus/Client/ParamsTest.php
+++ b/tests/Amadeus/Client/ParamsTest.php
@@ -24,7 +24,6 @@ namespace Test\Amadeus\Client;
 
 use Amadeus\Client\Params;
 use Psr\Log\NullLogger;
-use Psr\Log\Test\LoggerInterfaceTest;
 use Test\Amadeus\BaseTestCase;
 
 /**
@@ -64,8 +63,9 @@ class ParamsTest extends BaseTestCase
         $this->assertInstanceOf('Amadeus\Client\Params\SessionHandlerParams', $params->sessionHandlerParams);
         $this->assertTrue($params->sessionHandlerParams->stateful);
         $this->assertInstanceOf('Psr\Log\LoggerInterface', $params->sessionHandlerParams->logger);
-        $this->assertInternalType('string', $params->sessionHandlerParams->wsdl);
-        $this->assertEquals('/var/fake/file/path', $params->sessionHandlerParams->wsdl);
+        $this->assertInternalType('array', $params->sessionHandlerParams->wsdl);
+        $this->assertCount(1, $params->sessionHandlerParams->wsdl);
+        $this->assertEquals('/var/fake/file/path', $params->sessionHandlerParams->wsdl[0]);
 
         $this->assertInstanceOf('Amadeus\Client\Params\AuthParams', $params->sessionHandlerParams->authParams);
         $this->assertEquals('BRUXXXXXX', $params->sessionHandlerParams->authParams->officeId);

--- a/tests/Amadeus/Client/Session/Handler/HandlerFactoryTest.php
+++ b/tests/Amadeus/Client/Session/Handler/HandlerFactoryTest.php
@@ -72,6 +72,31 @@ class HandlerFactoryTest extends BaseTestCase
         $this->assertInstanceOf('Amadeus\Client\Session\Handler\SoapHeader4', $createdHandler);
     }
 
+    public function testCreateSoapHeader4WithWsdlListWillCreateSoapHeader4Handler()
+    {
+        $params = $par = new SessionHandlerParams([
+            'wsdl' => [
+                '/dummy/path',
+                '/dummy/path/wsdl2'
+            ],
+            'soapHeaderVersion' => Client::HEADER_V4,
+            'receivedFrom' => 'unittests',
+            'logger' => new NullLogger(),
+            'authParams' => [
+                'officeId' => 'BRUXX0000',
+                'originatorTypeCode' => 'U',
+                'userId' => 'DUMMYORIG',
+                'organizationId' => 'DUMMYORG',
+                'passwordLength' => 12,
+                'passwordData' => 'dGhlIHBhc3N3b3Jk'
+            ]
+        ]);
+
+        $createdHandler = HandlerFactory::createHandler($params);
+
+        $this->assertInstanceOf('Amadeus\Client\Session\Handler\SoapHeader4', $createdHandler);
+    }
+
     public function testCreateSoapHeader2WillCreateSoapHeader2Handler()
     {
         $params = $par = new SessionHandlerParams([

--- a/tests/Amadeus/Client/Session/Handler/SoapHeader2Test.php
+++ b/tests/Amadeus/Client/Session/Handler/SoapHeader2Test.php
@@ -104,6 +104,7 @@ class SoapHeader2Test extends BaseTestCase
         $expectedResult = new SendResult();
         $expectedResult->responseXml = $dummyPnrReplyExtractedMessage;
         $expectedResult->responseObject = new \stdClass();
+        $expectedResult->messageVersion = '11.3';
 
         $this->assertEquals($expectedResult, $messageResponse);
     }
@@ -188,7 +189,7 @@ class SoapHeader2Test extends BaseTestCase
 
         $handler = new SoapHeader2($handlerParams);
 
-        $result = $handler->getLastRequest();
+        $result = $handler->getLastRequest('PNR_Retrieve');
 
         $this->assertNull($result);
     }
@@ -246,6 +247,7 @@ class SoapHeader2Test extends BaseTestCase
             'receivedFrom' => 'unittests',
             'logger' => new NullLogger(),
             'overrideSoapClient' => $overrideSoapClient,
+            'overrideSoapClientWsdlName' => sprintf('%x', crc32($wsdlpath)),
             'authParams' => [
                 'officeId' => 'BRUXX0000',
                 'originatorTypeCode' => 'U',

--- a/tests/Amadeus/Client/Session/Handler/testfiles/PNR_Reply_11_3_1A.xsd
+++ b/tests/Amadeus/Client/Session/Handler/testfiles/PNR_Reply_11_3_1A.xsd
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://xml.amadeus.com/PNRACC_11_3_1A" xmlns="http://xml.amadeus.com/PNRACC_11_3_1A" elementFormDefault="qualified">
+    <xs:element name="PNR_Reply">
+    </xs:element>
+</xs:schema>

--- a/tests/Amadeus/Client/Session/Handler/testfiles/PNR_Retrieve_11_3_1A.xsd
+++ b/tests/Amadeus/Client/Session/Handler/testfiles/PNR_Retrieve_11_3_1A.xsd
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://xml.amadeus.com/PNRRET_11_3_1A" xmlns="http://xml.amadeus.com/PNRRET_11_3_1A" elementFormDefault="qualified">
+    <xs:element name="PNR_Retrieve">
+    </xs:element>
+</xs:schema>

--- a/tests/Amadeus/Client/Session/Handler/testfiles/Security_SignOutReply_04_1_1A.xsd
+++ b/tests/Amadeus/Client/Session/Handler/testfiles/Security_SignOutReply_04_1_1A.xsd
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://xml.amadeus.com/VLSSOR_04_1_1A" xmlns="http://xml.amadeus.com/VLSSOR_04_1_1A" elementFormDefault="qualified">
+    <xs:element name="Security_SignOutReply">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="errorSection" minOccurs="0">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="applicationError">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="errorDetails">
+                                            <xs:complexType>
+                                                <xs:sequence>
+                                                    <xs:element name="errorCode">
+                                                        <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                                <xs:annotation>
+                                                                    <xs:documentation xml:lang="en">Format limitations: an..5</xs:documentation>
+                                                                </xs:annotation>
+                                                                <xs:minLength value="1" />
+                                                                <xs:maxLength value="5" />
+                                                            </xs:restriction>
+                                                        </xs:simpleType>
+                                                    </xs:element>
+                                                    <xs:element name="errorCategory" minOccurs="0">
+                                                        <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                                <xs:annotation>
+                                                                    <xs:documentation xml:lang="en">Format limitations: an..3</xs:documentation>
+                                                                </xs:annotation>
+                                                                <xs:minLength value="1" />
+                                                                <xs:maxLength value="3" />
+                                                            </xs:restriction>
+                                                        </xs:simpleType>
+                                                    </xs:element>
+                                                    <xs:element name="errorCodeOwner" minOccurs="0">
+                                                        <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                                <xs:annotation>
+                                                                    <xs:documentation xml:lang="en">Format limitations: an..3</xs:documentation>
+                                                                </xs:annotation>
+                                                                <xs:minLength value="1" />
+                                                                <xs:maxLength value="3" />
+                                                            </xs:restriction>
+                                                        </xs:simpleType>
+                                                    </xs:element>
+                                                </xs:sequence>
+                                            </xs:complexType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="interactiveFreeText" minOccurs="0">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="freeTextQualification" minOccurs="0">
+                                            <xs:complexType>
+                                                <xs:sequence>
+                                                    <xs:element name="textSubjectQualifier">
+                                                        <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                                <xs:annotation>
+                                                                    <xs:documentation xml:lang="en">Format limitations: an..3</xs:documentation>
+                                                                </xs:annotation>
+                                                                <xs:minLength value="1" />
+                                                                <xs:maxLength value="3" />
+                                                            </xs:restriction>
+                                                        </xs:simpleType>
+                                                    </xs:element>
+                                                    <xs:element name="informationType" minOccurs="0">
+                                                        <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                                <xs:annotation>
+                                                                    <xs:documentation xml:lang="en">Format limitations: an..4</xs:documentation>
+                                                                </xs:annotation>
+                                                                <xs:minLength value="1" />
+                                                                <xs:maxLength value="4" />
+                                                            </xs:restriction>
+                                                        </xs:simpleType>
+                                                    </xs:element>
+                                                    <xs:element name="language" minOccurs="0">
+                                                        <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                                <xs:annotation>
+                                                                    <xs:documentation xml:lang="en">Format limitations: an..3</xs:documentation>
+                                                                </xs:annotation>
+                                                                <xs:minLength value="1" />
+                                                                <xs:maxLength value="3" />
+                                                            </xs:restriction>
+                                                        </xs:simpleType>
+                                                    </xs:element>
+                                                </xs:sequence>
+                                            </xs:complexType>
+                                        </xs:element>
+                                        <xs:element name="freeText" minOccurs="0" maxOccurs="99">
+                                            <xs:simpleType>
+                                                <xs:restriction base="xs:string">
+                                                    <xs:annotation>
+                                                        <xs:documentation xml:lang="en">Format limitations: an..70</xs:documentation>
+                                                    </xs:annotation>
+                                                    <xs:minLength value="1" />
+                                                    <xs:maxLength value="70" />
+                                                </xs:restriction>
+                                            </xs:simpleType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="processStatus" minOccurs="0">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="statusCode">
+                                <xs:simpleType>
+                                    <xs:restriction base="xs:string">
+                                        <xs:annotation>
+                                            <xs:documentation xml:lang="en">Format limitations: a..6</xs:documentation>
+                                        </xs:annotation>
+                                        <xs:minLength value="1" />
+                                        <xs:maxLength value="6" />
+                                    </xs:restriction>
+                                </xs:simpleType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/tests/Amadeus/Client/Session/Handler/testfiles/Security_SignOut_04_1_1A.xsd
+++ b/tests/Amadeus/Client/Session/Handler/testfiles/Security_SignOut_04_1_1A.xsd
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://xml.amadeus.com/VLSSOQ_04_1_1A" xmlns="http://xml.amadeus.com/VLSSOQ_04_1_1A" elementFormDefault="qualified">
+    <xs:element name="Security_SignOut">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="conversationClt" minOccurs="0">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="senderIdentification">
+                                <xs:simpleType>
+                                    <xs:restriction base="xs:string">
+                                        <xs:annotation>
+                                            <xs:documentation xml:lang="en">Format limitations: an..35</xs:documentation>
+                                        </xs:annotation>
+                                        <xs:minLength value="1" />
+                                        <xs:maxLength value="35" />
+                                    </xs:restriction>
+                                </xs:simpleType>
+                            </xs:element>
+                            <xs:element name="recipientIdentification">
+                                <xs:simpleType>
+                                    <xs:restriction base="xs:string">
+                                        <xs:annotation>
+                                            <xs:documentation xml:lang="en">Format limitations: an..35</xs:documentation>
+                                        </xs:annotation>
+                                        <xs:minLength value="1" />
+                                        <xs:maxLength value="35" />
+                                    </xs:restriction>
+                                </xs:simpleType>
+                            </xs:element>
+                            <xs:element name="senderInterchangeControlReference">
+                                <xs:simpleType>
+                                    <xs:restriction base="xs:string">
+                                        <xs:annotation>
+                                            <xs:documentation xml:lang="en">Format limitations: an..14</xs:documentation>
+                                        </xs:annotation>
+                                        <xs:minLength value="1" />
+                                        <xs:maxLength value="14" />
+                                    </xs:restriction>
+                                </xs:simpleType>
+                            </xs:element>
+                            <xs:element name="recipientInterchangeControlReference">
+                                <xs:simpleType>
+                                    <xs:restriction base="xs:string">
+                                        <xs:annotation>
+                                            <xs:documentation xml:lang="en">Format limitations: an..14</xs:documentation>
+                                        </xs:annotation>
+                                        <xs:minLength value="1" />
+                                        <xs:maxLength value="14" />
+                                    </xs:restriction>
+                                </xs:simpleType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/tests/Amadeus/Client/Session/Handler/testfiles/mediawsdl/AMA_MediaGetMediaRQ.xsd
+++ b/tests/Amadeus/Client/Session/Handler/testfiles/mediawsdl/AMA_MediaGetMediaRQ.xsd
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://xml.amadeus.com/2010/06/MediaServer_v1" targetNamespace="http://xml.amadeus.com/2010/06/MediaServer_v1" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.000" id="AMA2015A">
+  <xs:element name="AMA_MediaGetMediaRQ">
+  </xs:element>
+</xs:schema>
+

--- a/tests/Amadeus/Client/Session/Handler/testfiles/mediawsdl/AMA_MediaGetMediaRS.xsd
+++ b/tests/Amadeus/Client/Session/Handler/testfiles/mediawsdl/AMA_MediaGetMediaRS.xsd
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2013 rel. 2 sp2 (x64) (http://www.altova.com) by ﻿AMADEUS s.a.s. (AMADEUS s.a.s.) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://xml.amadeus.com/2010/06/MediaServer_v1" targetNamespace="http://xml.amadeus.com/2010/06/MediaServer_v1" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.000" id="AMA2015A">
+	<xs:element name="AMA_MediaGetMediaRS">
+	</xs:element>
+</xs:schema>

--- a/tests/Amadeus/Client/Session/Handler/testfiles/mediawsdl/DUMMYWSAP_MediaServer.wsdl
+++ b/tests/Amadeus/Client/Session/Handler/testfiles/mediawsdl/DUMMYWSAP_MediaServer.wsdl
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://wsdl.amadeus.com/MediaServer_v1_v4" xmlns:int="http://wsdl.amadeus.com/MediaServer_v1" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" name="_1AWDD_MediaServer_1.0_4.0" targetNamespace="http://wsdl.amadeus.com/MediaServer_v1_v4">
+	<wsdl:import namespace="http://wsdl.amadeus.com/MediaServer_v1" location="MediaServer_1.0.wsdl"/>
+	<wsdl:documentation>Versions: [interface: 1.0 ; technical: 4.0]</wsdl:documentation>
+	<wsdl:binding name="MediaServer_Binding" type="int:MediaServer_PT">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+		<wsdl:operation name="Media_GetMedia">
+			<soap:operation soapAction="http://dummy.media.soapaction.com"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:service name="MediaServer_Service">
+		<wsdl:port name="MediaServer_Port" binding="tns:MediaServer_Binding">
+			<soap:address location="https://dummy.media.endpoint.com/DUMMYWSAP"/>
+			<wsp:PolicyReference URI="#AmadeusPolicy"/>
+		</wsdl:port>
+	</wsdl:service>
+	<wsp:Policy wsu:Id="MessagingPolicy">
+		<wsam:Addressing wsp:Optional="true">
+			<wsp:Policy>
+				<wsam:AnonymousResponses/>
+			</wsp:Policy>
+		</wsam:Addressing>
+	</wsp:Policy>
+	<wsp:Policy wsu:Id="AmadeusPolicy">
+		<wsp:PolicyReference URI="#MessagingPolicy"/>
+	</wsp:Policy>
+</wsdl:definitions>

--- a/tests/Amadeus/Client/Session/Handler/testfiles/mediawsdl/DUMMYWSAP_MediaServer_invalid.wsdl
+++ b/tests/Amadeus/Client/Session/Handler/testfiles/mediawsdl/DUMMYWSAP_MediaServer_invalid.wsdl
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://wsdl.amadeus.com/MediaServer_v1_v4" xmlns:int="http://wsdl.amadeus.com/MediaServer_v1" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" name="_1AWDD_MediaServer_1.0_4.0" targetNamespace="http://wsdl.amadeus.com/MediaServer_v1_v4">
+	<wsdl:import namespace="http://wsdl.amadeus.com/MediaServer_v1" location="invalid.wsdl"/>
+	<wsdl:documentation>Versions: [interface: 1.0 ; technical: 4.0]</wsdl:documentation>
+	<wsdl:binding name="MediaServer_Binding" type="int:MediaServer_PT">
+		<soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+		<wsdl:operation name="Media_GetMedia">
+			<soap:operation soapAction="http://dummy.media.soapaction.com"/>
+			<wsdl:input>
+				<soap:body use="literal"/>
+			</wsdl:input>
+			<wsdl:output>
+				<soap:body use="literal"/>
+			</wsdl:output>
+		</wsdl:operation>
+	</wsdl:binding>
+	<wsdl:service name="MediaServer_Service">
+		<wsdl:port name="MediaServer_Port" binding="tns:MediaServer_Binding">
+			<soap:address location="https://dummy.media.endpoint.com/DUMMYWSAP"/>
+			<wsp:PolicyReference URI="#AmadeusPolicy"/>
+		</wsdl:port>
+	</wsdl:service>
+	<wsp:Policy wsu:Id="MessagingPolicy">
+		<wsam:Addressing wsp:Optional="true">
+			<wsp:Policy>
+				<wsam:AnonymousResponses/>
+			</wsp:Policy>
+		</wsam:Addressing>
+	</wsp:Policy>
+	<wsp:Policy wsu:Id="AmadeusPolicy">
+		<wsp:PolicyReference URI="#MessagingPolicy"/>
+	</wsp:Policy>
+</wsdl:definitions>

--- a/tests/Amadeus/Client/Session/Handler/testfiles/mediawsdl/MediaServer_1.0.wsdl
+++ b/tests/Amadeus/Client/Session/Handler/testfiles/mediawsdl/MediaServer_1.0.wsdl
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://wsdl.amadeus.com/MediaServer_v1" xmlns:ama_2010_06_MediaServer_v1="http://xml.amadeus.com/2010/06/MediaServer_v1" targetNamespace="http://wsdl.amadeus.com/MediaServer_v1" name="MediaServer_1.0">
+  <wsdl:documentation>Version 1.0</wsdl:documentation>
+  <wsdl:types>
+    <xs:schema>
+      <xs:import namespace="http://xml.amadeus.com/2010/06/MediaServer_v1" schemaLocation="AMA_MediaGetMediaRQ.xsd" />
+      <xs:import namespace="http://xml.amadeus.com/2010/06/MediaServer_v1" schemaLocation="AMA_MediaGetMediaRS.xsd" />
+    </xs:schema>
+  </wsdl:types>
+  <wsdl:message name="AMA_MediaGetMediaRQ_1.000">
+    <wsdl:part name="body" element="ama_2010_06_MediaServer_v1:AMA_MediaGetMediaRQ" />
+  </wsdl:message>
+  <wsdl:message name="AMA_MediaGetMediaRS_1.000">
+    <wsdl:part name="body" element="ama_2010_06_MediaServer_v1:AMA_MediaGetMediaRS" />
+  </wsdl:message>
+  <wsdl:portType name="MediaServer_PT">
+    <wsdl:operation name="Media_GetMedia">
+      <wsdl:documentation>Version 1.0</wsdl:documentation>
+      <wsdl:input message="tns:AMA_MediaGetMediaRQ_1.000" />
+      <wsdl:output message="tns:AMA_MediaGetMediaRS_1.000" />
+    </wsdl:operation>
+  </wsdl:portType>
+</wsdl:definitions>
+

--- a/tests/Amadeus/Client/Session/Handler/testfiles/soapheader2/PNR_Reply_11_3_1A.xsd
+++ b/tests/Amadeus/Client/Session/Handler/testfiles/soapheader2/PNR_Reply_11_3_1A.xsd
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://xml.amadeus.com/PNRACC_11_3_1A" xmlns="http://xml.amadeus.com/PNRACC_11_3_1A" elementFormDefault="qualified">
+    <xs:element name="PNR_Reply">
+    </xs:element>
+</xs:schema>

--- a/tests/Amadeus/Client/Session/Handler/testfiles/soapheader2/PNR_Retrieve_11_3_1A.xsd
+++ b/tests/Amadeus/Client/Session/Handler/testfiles/soapheader2/PNR_Retrieve_11_3_1A.xsd
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://xml.amadeus.com/PNRRET_11_3_1A" xmlns="http://xml.amadeus.com/PNRRET_11_3_1A" elementFormDefault="qualified">
+    <xs:element name="PNR_Retrieve">
+    </xs:element>
+</xs:schema>

--- a/tests/Amadeus/Client/Session/Handler/testfiles/soapheader2/testwsdlsoapheader2.wsdl
+++ b/tests/Amadeus/Client/Session/Handler/testfiles/soapheader2/testwsdlsoapheader2.wsdl
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:aws="http://xml.amadeus.com" xmlns:security_signout_4_1="http://xml.amadeus.com/VLSSOQ_04_1_1A" xmlns:security_signoutreply_4_1="http://xml.amadeus.com/VLSSOR_04_1_1A" xmlns:security_authenticate_6_1="http://xml.amadeus.com/VLSSLQ_06_1_1A" xmlns:security_authenticatereply_6_1="http://xml.amadeus.com/VLSSLR_06_1_1A" xmlns:pricexplorer_extremesearch_10_3="http://xml.amadeus.com/FAESXQ_10_3_1A" xmlns:pricexplorer_extremesearchreply_10_3="http://xml.amadeus.com/FAESXR_10_3_1A" targetNamespace="http://xml.amadeus.com">
     <wsdl:types>
         <xsd:schema targetNamespace="http://xml.amadeus.com">
@@ -10,6 +9,8 @@
             <xsd:import namespace="http://xml.amadeus.com/VLSSLR_06_1_1A" schemaLocation="Security_AuthenticateReply_06_1_1A.xsd"/>
             <xsd:import namespace="http://xml.amadeus.com/FAESXQ_10_3_1A" schemaLocation="PriceXplorer_ExtremeSearch_10_3_1A.xsd"/>
             <xsd:import namespace="http://xml.amadeus.com/FAESXR_10_3_1A" schemaLocation="PriceXplorer_ExtremeSearchReply_10_3_1A.xsd"/>
+            <xsd:import schemaLocation="PNR_Reply_11_3_1A.xsd" namespace="http://xml.amadeus.com/PNRACC_11_3_1A"/>
+            <xsd:import schemaLocation="PNR_Retrieve_11_3_1A.xsd" namespace="http://xml.amadeus.com/PNRRET_11_3_1A"/>
         </xsd:schema>
     </wsdl:types>
     <wsdl:message name="Session" xmlns:ns0="http://xml.amadeus.com/ws/2009/01/WBS_Session-2.0.xsd">
@@ -33,6 +34,12 @@
     <wsdl:message name="PriceXplorer_ExtremeSearchReply_10_3">
         <wsdl:part name="PriceXplorer_ExtremeSearchReply_10_3" element="pricexplorer_extremesearchreply_10_3:PriceXplorer_ExtremeSearchReply"/>
     </wsdl:message>
+    <wsdl:message name="PNR_Reply_11_3">
+        <wsdl:part name="PNR_Reply_11_3" element="pnr_reply_11_3:PNR_Reply"/>
+    </wsdl:message>
+    <wsdl:message name="PNR_Retrieve_11_3">
+        <wsdl:part name="PNR_Retrieve_11_3" element="pnr_retrieve_11_3:PNR_Retrieve"/>
+    </wsdl:message>
     <wsdl:portType name="AmadeusWebServicesPT">
         <wsdl:operation name="Security_SignOut">
             <wsdl:input message="aws:Security_SignOut_4_1"/>
@@ -45,6 +52,10 @@
         <wsdl:operation name="PriceXplorer_ExtremeSearch">
             <wsdl:input message="aws:PriceXplorer_ExtremeSearch_10_3"/>
             <wsdl:output message="aws:PriceXplorer_ExtremeSearchReply_10_3"/>
+        </wsdl:operation>
+        <wsdl:operation name="PNR_Retrieve">
+            <wsdl:input message="aws:PNR_Retrieve_11_3"/>
+            <wsdl:output message="aws:PNR_Reply_11_3"/>
         </wsdl:operation>
     </wsdl:portType>
     <wsdl:binding name="AmadeusWebServicesBinding" type="aws:AmadeusWebServicesPT">


### PR DESCRIPTION
As mentioned in #5 this PR adds support for handling multiple WSDL's in one WSAP (Profile, Media, ...).

Messages that use separate WSDL's are currently not yet supported, but can now be added without too much trouble.