### PR TITLE
Added fee ids to MasterPricer

### DIFF
--- a/docs/samples/masterpricertravelboard.rst
+++ b/docs/samples/masterpricertravelboard.rst
@@ -727,7 +727,7 @@ Here is example how to get information about airlines fare families and get addi
             ])
         ],
         'feeIds' => [
-            new MPFeeId(['type' => 'FFI', 'number' => 3]),
-            new MPFeeId(['type' => 'UPH', 'number' => 6])
+            new MPFeeId(['type' => MPFeeId::FEETYPE_FARE_FAMILY_INFORMATION, 'number' => 3]),
+            new MPFeeId(['type' => MPFeeId::FEETYPE_HOMOGENOUS_UPSELL, 'number' => 6])
         ]
     ]);

--- a/docs/samples/masterpricertravelboard.rst
+++ b/docs/samples/masterpricertravelboard.rst
@@ -691,3 +691,43 @@ Alternate Fare Family:
         ]
     ]);
 
+
+
+Special parameters (FeeIds)
+===========================
+
+To turn on some functions in MasterPricer, you have to send special parameter (sometimes specific function has to be enabled for your office id).
+
+Here is example how to get information about airlines fare families and get additional recommendation for homogoneus upsell:
+
+.. code-block:: php
+
+    use Amadeus\Client\RequestOptions\FareMasterPricerTbSearch;
+    use Amadeus\Client\RequestOptions\Fare\MPItinerary;
+    use Amadeus\Client\RequestOptions\Fare\MPLocation;
+    use Amadeus\Client\RequestOptionsFare\MPPassenger;
+    use Amadeus\Client\RequestOptionsFare\MPDate;
+    use Amadeus\Client\RequestOptions\Fare\MPFeeId;
+
+    $opt = new FareMasterPricerTbSearch([
+        'nrOfRequestedPassengers' => 1,
+        'passengers' => [
+            new MPPassenger([
+                'type' => MPPassenger::TYPE_ADULT,
+                'count' => 1
+            ])
+        ],
+        'itinerary' => [
+            new MPItinerary([
+                'departureLocation' => new MPLocation(['city' => 'BRU']),
+                'arrivalLocation' => new MPLocation(['city' => 'LON']),
+                'date' => new MPDate([
+                    'dateTime' => new \DateTime('2017-01-15T00:00:00+0000', new \DateTimeZone('UTC'))
+                ])
+            ])
+        ],
+        'feeIds' => [
+            new MPFeeId(['type' => 'FFI', 'number' => 3]),
+            new MPFeeId(['type' => 'UPH', 'number' => 6])
+        ]
+    ]);

--- a/src/Amadeus/Client/RequestOptions/Fare/MPFeeId.php
+++ b/src/Amadeus/Client/RequestOptions/Fare/MPFeeId.php
@@ -48,7 +48,7 @@ class MPFeeId extends LoadParamsFromArray
      * Fee Type
      *
      * self::FEETYPE_*
-     * 
+     *
      * @var string
      */
     public $type;

--- a/src/Amadeus/Client/RequestOptions/Fare/MPFeeId.php
+++ b/src/Amadeus/Client/RequestOptions/Fare/MPFeeId.php
@@ -20,33 +20,29 @@
  * @license https://opensource.org/licenses/Apache-2.0 Apache 2.0
  */
 
-namespace Amadeus\Client\Struct\Fare\MasterPricer;
+namespace Amadeus\Client\RequestOptions\Fare;
+
+use Amadeus\Client\LoadParamsFromArray;
 
 /**
- * FeeId
+ * MasterPricer Fee Id request options.
  *
- * @package Amadeus\Client\Struct\Fare\MasterPricer
+ * @package Amadeus\Client\RequestOptions\Fare
  * @author Dieter Devlieghere <dieter.devlieghere@benelux.amadeus.com>
  */
-class FeeId
+class MPFeeId extends LoadParamsFromArray
 {
-    public $feeType;
-
-    public $feeIdNumber;
+    /**
+     * Fee Type
+     *
+     * @var string
+     */
+    public $type;
 
     /**
-      * FeeId constructor.
-      *
-      * @param string|null $feeType
-      * @param int|null $feeIdNumber
-      */
-     public function __construct($feeType = null, $feeIdNumber = null)
-     {
-         if (!is_null($feeType)) {
-             $this->feeType = $feeType;
-         }
-         if (!is_null($feeIdNumber)) {
-             $this->feeIdNumber = $feeIdNumber;
-         }
-     }
+     * Fee Id
+     *
+     * @var int
+     */
+    public $number;
 }

--- a/src/Amadeus/Client/RequestOptions/Fare/MPFeeId.php
+++ b/src/Amadeus/Client/RequestOptions/Fare/MPFeeId.php
@@ -32,9 +32,23 @@ use Amadeus\Client\LoadParamsFromArray;
  */
 class MPFeeId extends LoadParamsFromArray
 {
+    const FEETYPE_ARP_NUMBER = "ARP";
+    const FEETYPE_FREE_BAGGAGE_ALLOWANCE = "FBA";
+    const FEETYPE_FARE_FAMILY_INFORMATION = "FFI";
+    const FEETYPE_NO_PNR_SPLIT = "NPS";
+    const FEETYPE_PRICE_TO_REACH_AMOUNT_TYPE = "PTRAM";
+    const FEETYPE_HAL_ROUND_TRIP_COMBINATION = "RTC";
+    const FEETYPE_SEARCH_BY_FBA = "SBF";
+    const FEETYPE_SORTING_OPTION = "SORT";
+    const FEETYPE_TOKEN = "TOKEN";
+    const FEETYPE_UPSELL_PER_BOUND = "UPB";
+    const FEETYPE_HOMOGENOUS_UPSELL = "UPH";
+    
     /**
      * Fee Type
      *
+     * self::FEETYPE_*
+     * 
      * @var string
      */
     public $type;

--- a/src/Amadeus/Client/RequestOptions/FareMasterPricerTbSearch.php
+++ b/src/Amadeus/Client/RequestOptions/FareMasterPricerTbSearch.php
@@ -155,6 +155,13 @@ class FareMasterPricerTbSearch extends Base
     public $currencyOverride;
 
     /**
+     * FeeIds you want to pass on fare options level.
+     *
+     * @var Fare\MPFeeId[]
+     */
+    public $feeIds;
+
+    /**
      * Cabin class requested for the entire itinerary
      *
      * self::CABIN_*

--- a/src/Amadeus/Client/Struct/Fare/MasterPricer/FareOptions.php
+++ b/src/Amadeus/Client/Struct/Fare/MasterPricer/FareOptions.php
@@ -62,8 +62,9 @@ class FareOptions
      * @param array $corpCodesUniFares list of Corporate codes for Corporate Unifares
      * @param bool $tickPreCheck Do Ticketability pre-check?
      * @param string|null $currency Override Currency conversion
+     * @param array|null $flightOptions List of FeeIds
      */
-    public function __construct(array $flightOptions, array $corpCodesUniFares, $tickPreCheck, $currency)
+    public function __construct(array $flightOptions, array $corpCodesUniFares, $tickPreCheck, $currency, $feeIds)
     {
         if ($tickPreCheck === true) {
             $this->addPriceType(PricingTicketing::PRICETYPE_TICKETABILITY_PRECHECK);
@@ -79,6 +80,24 @@ class FareOptions
         }
 
         $this->loadCurrencyOverride($currency);
+        if (!is_null($feeIds)) {
+            $this->loadFeeIds($feeIds);
+        }
+    }
+
+    /**
+     * Set fee ids if needed
+     *
+     * @param string|null $currency
+     */
+    protected function loadFeeIds($feeIds)
+    {
+        if (is_null($this->feeIdDescription)) {
+            $this->feeIdDescription = new FeeIdDescription();
+        }
+        foreach ($feeIds as $feeId) {
+            $this->feeIdDescription->feeId[] = new FeeId($feeId->type, $feeId->number);
+        }
     }
 
     /**

--- a/src/Amadeus/Client/Struct/Fare/MasterPricer/FareOptions.php
+++ b/src/Amadeus/Client/Struct/Fare/MasterPricer/FareOptions.php
@@ -62,7 +62,7 @@ class FareOptions
      * @param array $corpCodesUniFares list of Corporate codes for Corporate Unifares
      * @param bool $tickPreCheck Do Ticketability pre-check?
      * @param string|null $currency Override Currency conversion
-     * @param array|null $flightOptions List of FeeIds
+     * @param \Amadeus\Client\RequestOptions\Fare\MPFeeId[]|null $flightOptions List of FeeIds
      */
     public function __construct(array $flightOptions, array $corpCodesUniFares, $tickPreCheck, $currency, $feeIds)
     {
@@ -88,7 +88,7 @@ class FareOptions
     /**
      * Set fee ids if needed
      *
-     * @param string|null $currency
+     * @param \Amadeus\Client\RequestOptions\Fare\MPFeeId[] $feeIds
      */
     protected function loadFeeIds($feeIds)
     {

--- a/src/Amadeus/Client/Struct/Fare/MasterPricer/FeeId.php
+++ b/src/Amadeus/Client/Struct/Fare/MasterPricer/FeeId.php
@@ -30,8 +30,32 @@ namespace Amadeus\Client\Struct\Fare\MasterPricer;
  */
 class FeeId
 {
+    const FEETYPE_ARP_NUMBER = "ARP";
+    const FEETYPE_FREE_BAGGAGE_ALLOWANCE = "FBA";
+    const FEETYPE_FARE_FAMILY_INFORMATION = "FFI";
+    const FEETYPE_NO_PNR_SPLIT = "NPS";
+    const FEETYPE_PRICE_TO_REACH_AMOUNT_TYPE = "PTRAM";
+    const FEETYPE_HAL_ROUND_TRIP_COMBINATION = "RTC";
+    const FEETYPE_SEARCH_BY_FBA = "SBF";
+    const FEETYPE_SORTING_OPTION = "SORT";
+    const FEETYPE_TOKEN = "TOKEN";
+    const FEETYPE_UPSELL_PER_BOUND = "UPB";
+    const FEETYPE_HOMOGENOUS_UPSELL = "UPH";
+
+    /**
+     * Fee Type
+     *
+     * self::FEETYPE_*
+     * 
+     * @var string
+     */
     public $feeType;
 
+    /**
+     * Fee Id Number
+     *
+     * @var int
+     */
     public $feeIdNumber;
 
     /**

--- a/src/Amadeus/Client/Struct/Fare/MasterPricer/FeeId.php
+++ b/src/Amadeus/Client/Struct/Fare/MasterPricer/FeeId.php
@@ -46,7 +46,7 @@ class FeeId
      * Fee Type
      *
      * self::FEETYPE_*
-     * 
+     *
      * @var string
      */
     public $feeType;

--- a/src/Amadeus/Client/Struct/Fare/MasterPricerTravelBoardSearch.php
+++ b/src/Amadeus/Client/Struct/Fare/MasterPricerTravelBoardSearch.php
@@ -141,13 +141,14 @@ class MasterPricerTravelBoardSearch extends BaseWsMessage
         $this->loadNrOfPaxAndResults($options);
 
         if ($options->doTicketabilityPreCheck === true ||
-            $this->checkAnyNotEmpty($options->corporateCodesUnifares, $options->flightOptions, $options->currencyOverride)
+            $this->checkAnyNotEmpty($options->corporateCodesUnifares, $options->flightOptions, $options->currencyOverride, $options->feeIds)
         ) {
             $this->fareOptions = new MasterPricer\FareOptions(
                 $options->flightOptions,
                 $options->corporateCodesUnifares,
                 $options->doTicketabilityPreCheck,
-                $options->currencyOverride
+                $options->currencyOverride,
+                $options->feeIds
             );
         }
 

--- a/tests/Amadeus/Client/Struct/Fare/MasterPricerTravelBoardSearchTest.php
+++ b/tests/Amadeus/Client/Struct/Fare/MasterPricerTravelBoardSearchTest.php
@@ -29,6 +29,7 @@ use Amadeus\Client\RequestOptions\Fare\MPFareFamily;
 use Amadeus\Client\RequestOptions\Fare\MPItinerary;
 use Amadeus\Client\RequestOptions\Fare\MPLocation;
 use Amadeus\Client\RequestOptions\Fare\MPPassenger;
+use Amadeus\Client\RequestOptions\Fare\MPFeeId;
 use Amadeus\Client\RequestOptions\FareMasterPricerTbSearch;
 use Amadeus\Client\Struct\Fare\MasterPricer\BooleanExpression;
 use Amadeus\Client\Struct\Fare\MasterPricer\CabinId;
@@ -312,6 +313,41 @@ class MasterPricerTravelBoardSearchTest extends BaseTestCase
         $this->assertCount(1, $message->fareOptions->conversionRate->conversionRateDetail);
         $this->assertEquals('USD', $message->fareOptions->conversionRate->conversionRateDetail[0]->currency);
         $this->assertNull($message->fareOptions->conversionRate->conversionRateDetail[0]->conversionType);
+    }
+
+    public function testCanMakeMasterPricerMessageWithFeeIds()
+    {
+        $opt = new FareMasterPricerTbSearch([
+            'nrOfRequestedResults' => 200,
+            'nrOfRequestedPassengers' => 1,
+            'passengers' => [
+                new MPPassenger([
+                    'type' => MPPassenger::TYPE_ADULT,
+                    'count' => 1
+                ])
+            ],
+            'itinerary' => [
+                new MPItinerary([
+                    'departureLocation' => new MPLocation(['city' => 'BRU']),
+                    'arrivalLocation' => new MPLocation(['city' => 'LON']),
+                    'date' => new MPDate([
+                        'dateTime' => new \DateTime('2017-01-15T00:00:00+0000', new \DateTimeZone('UTC'))
+                    ])
+                ])
+            ],
+            'feeIds' => [
+                new MPFeeId(['type' => 'FFI', 'number' => 2]),
+                new MPFeeId(['type' => 'UPH', 'number' => 6])
+            ]
+        ]);
+
+        $message = new MasterPricerTravelBoardSearch($opt);
+
+        $this->assertCount(2, $message->fareOptions->feeIdDescription->feeId);
+        $this->assertEquals('FFI', $message->fareOptions->feeIdDescription->feeId[0]->feeType);
+        $this->assertEquals(2, $message->fareOptions->feeIdDescription->feeId[0]->feeIdNumber);
+        $this->assertEquals('UPH', $message->fareOptions->feeIdDescription->feeId[1]->feeType);
+        $this->assertEquals(6, $message->fareOptions->feeIdDescription->feeId[1]->feeIdNumber);
     }
 
     public function testCanMakeMasterPricerMessageWithCabinClassAndCod()


### PR DESCRIPTION
Hey, I felt bad about just asking so I wanted to contribute a little bit.

Here is option to add FeeIds when searching in MasterPricer.

Possible options I saw in Amadeus.
```
FFI - shows fare family names from airlines (ex. Economy Saver)
UPH/UPB - upsell, so each recommendation gets reference to more expensive fares
```
Tell me if you want me to change anything! 

Cheers, Mike.