### PR TITLE
Bug with corporate Unifare pricing in Master Pricer

### DIFF
--- a/docs/samples/masterpricertravelboard.rst
+++ b/docs/samples/masterpricertravelboard.rst
@@ -366,7 +366,8 @@ Simple flight, request published fares, unifares and corporate unifares (with a 
             FareMasterPricerTbSearch::FLIGHTOPT_UNIFARES,
             FareMasterPricerTbSearch::FLIGHTOPT_CORPORATE_UNIFARES,
         ],
-        'corporateCodesUnifares' => ['123456']
+        'corporateCodesUnifares' => ['123456'],
+        'corporateQualifier' => FareMasterPricerTbSearch::CORPORATE_QUALIFIER_UNIFARE
     ]);
 
 

--- a/src/Amadeus/Client/RequestOptions/FareMasterPricerTbSearch.php
+++ b/src/Amadeus/Client/RequestOptions/FareMasterPricerTbSearch.php
@@ -64,6 +64,9 @@ class FareMasterPricerTbSearch extends Base
     const FLIGHTOPT_NO_SLICE_AND_DICE = "NSD";
     const FLIGHTOPT_DISPLAY_MIN_MAX_STAY = "MST";
 
+    const CORPORATE_QUALIFIER_AMADEUS_NEGO = "RC";
+    const CORPORATE_QUALIFIER_UNIFARE = "RW";
+
     /**
      * Major cabin
      */
@@ -140,6 +143,17 @@ class FareMasterPricerTbSearch extends Base
      * @var string[]
      */
     public $corporateCodesUnifares = [];
+
+    /**
+     * Corporate qualifier for returning Corporate Unifares
+     *
+     * In combination with fareType self::FARETYPE::CORPORATE_UNIFARES
+     *
+     * self::CORPORATE_QUALIFIER_*
+     *
+     * @var string
+     */
+    public $corporateQualifier;
 
     /**
      * The currency to convert to.

--- a/src/Amadeus/Client/Struct/Fare/MasterPricer/CorporateId.php
+++ b/src/Amadeus/Client/Struct/Fare/MasterPricer/CorporateId.php
@@ -30,7 +30,12 @@ namespace Amadeus\Client\Struct\Fare\MasterPricer;
  */
 class CorporateId
 {
+    const CORPORATE_QUALIFIER_AMADEUS_NEGO = "RC";
+    const CORPORATE_QUALIFIER_UNIFARE = "RW";
+
     /**
+     * self::CORPORATE_QUALIFIER_*
+     *
      * @var string
      */
     public $corporateQualifier;
@@ -44,8 +49,9 @@ class CorporateId
      *
      * @param string[] $identity
      */
-    public function __construct($identity)
+    public function __construct($identity, $corporateQualifier)
     {
         $this->identity = $identity;
+        $this->corporateQualifier = $corporateQualifier;
     }
 }

--- a/src/Amadeus/Client/Struct/Fare/MasterPricer/FareOptions.php
+++ b/src/Amadeus/Client/Struct/Fare/MasterPricer/FareOptions.php
@@ -63,8 +63,9 @@ class FareOptions
      * @param bool $tickPreCheck Do Ticketability pre-check?
      * @param string|null $currency Override Currency conversion
      * @param \Amadeus\Client\RequestOptions\Fare\MPFeeId[]|null $flightOptions List of FeeIds
+     * @param string|null Corporate qualifier for Corporate Unifares
      */
-    public function __construct(array $flightOptions, array $corpCodesUniFares, $tickPreCheck, $currency, $feeIds)
+    public function __construct(array $flightOptions, array $corpCodesUniFares, $tickPreCheck, $currency, $feeIds, $corporateQualifier)
     {
         if ($tickPreCheck === true) {
             $this->addPriceType(PricingTicketing::PRICETYPE_TICKETABILITY_PRECHECK);
@@ -75,7 +76,7 @@ class FareOptions
 
             if ($flightOption === PricingTicketing::PRICETYPE_CORPORATE_UNIFARES) {
                 $this->corporate = new Corporate();
-                $this->corporate->corporateId[] = new CorporateId($corpCodesUniFares);
+                $this->corporate->corporateId[] = new CorporateId($corpCodesUniFares, $corporateQualifier);
             }
         }
 

--- a/src/Amadeus/Client/Struct/Fare/MasterPricerTravelBoardSearch.php
+++ b/src/Amadeus/Client/Struct/Fare/MasterPricerTravelBoardSearch.php
@@ -148,7 +148,8 @@ class MasterPricerTravelBoardSearch extends BaseWsMessage
                 $options->corporateCodesUnifares,
                 $options->doTicketabilityPreCheck,
                 $options->currencyOverride,
-                $options->feeIds
+                $options->feeIds,
+                $options->corporateQualifier
             );
         }
 

--- a/tests/Amadeus/Client/Struct/Fare/MasterPricerTravelBoardSearchTest.php
+++ b/tests/Amadeus/Client/Struct/Fare/MasterPricerTravelBoardSearchTest.php
@@ -665,7 +665,8 @@ class MasterPricerTravelBoardSearchTest extends BaseTestCase
                 FareMasterPricerTbSearch::FLIGHTOPT_UNIFARES,
                 FareMasterPricerTbSearch::FLIGHTOPT_CORPORATE_UNIFARES,
             ],
-            'corporateCodesUnifares' => ['123456']
+            'corporateCodesUnifares' => ['123456'],
+            'corporateQualifier' => FareMasterPricerTbSearch::CORPORATE_QUALIFIER_UNIFARE
         ]);
 
         $message = new MasterPricerTravelBoardSearch($opt);
@@ -680,6 +681,7 @@ class MasterPricerTravelBoardSearchTest extends BaseTestCase
             $message->fareOptions->pricingTickInfo->pricingTicketing->priceType
         );
         $this->assertEquals('123456', $message->fareOptions->corporate->corporateId[0]->identity[0]);
+        $this->assertEquals(FareMasterPricerTbSearch::CORPORATE_QUALIFIER_UNIFARE, $message->fareOptions->corporate->corporateId[0]->corporateQualifier);
     }
 
     public function testCanMakeMessageWithPriceToBeat()


### PR DESCRIPTION
Hey, fix for Master Pricer to support corporate pricing. 
I have no idea if it worked before, but I just checked with our access and Amadeus was raising an error that it is missing qualifier (also docs mention it)