### PR TITLE
Option to retrieve PNR that is active in context

### DIFF
--- a/src/Amadeus/Client/RequestCreator/Converter/PNR/RetrieveConv.php
+++ b/src/Amadeus/Client/RequestCreator/Converter/PNR/RetrieveConv.php
@@ -41,6 +41,15 @@ class RetrieveConv extends BaseConverter
      */
     public function convert($requestOptions, $version)
     {
+        if(!$requestOptions->recordLocator) {
+            $retrieveRequest = new Struct\Pnr\Retrieve(
+                Struct\Pnr\Retrieve::RETR_ACTIVE_PNR,
+                null
+            );
+    
+            return $retrieveRequest;
+        }
+        
         $retrieveRequest = new Struct\Pnr\Retrieve(
             Struct\Pnr\Retrieve::RETR_TYPE_BY_RECLOC,
             $requestOptions->recordLocator

--- a/src/Amadeus/Client/RequestCreator/Converter/PNR/RetrieveConv.php
+++ b/src/Amadeus/Client/RequestCreator/Converter/PNR/RetrieveConv.php
@@ -43,7 +43,7 @@ class RetrieveConv extends BaseConverter
     {
         if(!$requestOptions->recordLocator) {
             $retrieveRequest = new Struct\Pnr\Retrieve(
-                Struct\Pnr\Retrieve::RETR_ACTIVE_PNR,
+                Struct\Pnr\Retrieve::RETR_TYPE_ACTIVE_PNR,
                 null
             );
     

--- a/src/Amadeus/Client/RequestCreator/Converter/PNR/RetrieveConv.php
+++ b/src/Amadeus/Client/RequestCreator/Converter/PNR/RetrieveConv.php
@@ -41,7 +41,7 @@ class RetrieveConv extends BaseConverter
      */
     public function convert($requestOptions, $version)
     {
-        if(!$requestOptions->recordLocator) {
+        if (!$requestOptions->recordLocator) {
             $retrieveRequest = new Struct\Pnr\Retrieve(
                 Struct\Pnr\Retrieve::RETR_TYPE_ACTIVE_PNR,
                 null

--- a/src/Amadeus/Client/Struct/Pnr/Retrieve.php
+++ b/src/Amadeus/Client/Struct/Pnr/Retrieve.php
@@ -41,6 +41,7 @@ class Retrieve extends BaseWsMessage
      * @var int
      */
     const RETR_TYPE_BY_RECLOC = 2;
+    const RETR_ACTIVE_PNR = 1;
     
     /**
      * @var Retrieve\Settings

--- a/src/Amadeus/Client/Struct/Pnr/Retrieve.php
+++ b/src/Amadeus/Client/Struct/Pnr/Retrieve.php
@@ -41,7 +41,7 @@ class Retrieve extends BaseWsMessage
      * @var int
      */
     const RETR_TYPE_BY_RECLOC = 2;
-    const RETR_ACTIVE_PNR = 1;
+    const RETR_TYPE_ACTIVE_PNR = 1;
     
     /**
      * @var Retrieve\Settings

--- a/tests/Amadeus/Client/RequestCreator/BaseTest.php
+++ b/tests/Amadeus/Client/RequestCreator/BaseTest.php
@@ -119,6 +119,31 @@ class BaseTest extends BaseTestCase
 
         $this->assertNull($message->settings);
     }
+    
+    public function testCanCreatePnrRetrieveMessageInContext()
+    {
+        $par = new RequestCreatorParams([
+            'originatorOfficeId' => 'BRUXXXXXX',
+            'receivedFrom' => 'some RF string',
+            'messagesAndVersions' => ['PNR_Retrieve' => ['version' => '14.2', 'wsdl' => 'aabbccdd']]
+        ]);
+
+        $rq = new Base($par);
+
+        $message = $rq->createRequest(
+            'PNR_Retrieve',
+            new PnrRetrieveOptions()
+        );
+
+        $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\Retrieve', $message);
+        /** @var Retrieve $message */
+        $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\Retrieve\RetrievalFacts', $message->retrievalFacts);
+        $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\Retrieve\Retrieve', $message->retrievalFacts->retrieve);
+        $this->assertEquals(Retrieve::RETR_ACTIVE_PNR, $message->retrievalFacts->retrieve->type);
+        $this->assertNull($message->retrievalFacts->reservationOrProfileIdentifier);
+
+        $this->assertNull($message->settings);
+    }
 
     public function testCanCreatePnrRetrieveAndDisplayMessage()
     {

--- a/tests/Amadeus/Client/RequestCreator/BaseTest.php
+++ b/tests/Amadeus/Client/RequestCreator/BaseTest.php
@@ -139,7 +139,7 @@ class BaseTest extends BaseTestCase
         /** @var Retrieve $message */
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\Retrieve\RetrievalFacts', $message->retrievalFacts);
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\Retrieve\Retrieve', $message->retrievalFacts->retrieve);
-        $this->assertEquals(Retrieve::RETR_ACTIVE_PNR, $message->retrievalFacts->retrieve->type);
+        $this->assertEquals(Retrieve::RETR_TYPE_ACTIVE_PNR, $message->retrievalFacts->retrieve->type);
         $this->assertNull($message->retrievalFacts->reservationOrProfileIdentifier);
 
         $this->assertNull($message->settings);

--- a/tests/Amadeus/Client/Struct/Pnr/RetrieveTest.php
+++ b/tests/Amadeus/Client/Struct/Pnr/RetrieveTest.php
@@ -49,4 +49,21 @@ class RetrieveTest extends BaseTestCase
 
         $this->assertNull($message->settings);
     }
+    
+    public function testCanCreatePnrRetrieveMessageInContext()
+    {
+        $message = new Pnr\Retrieve(
+            Pnr\Retrieve::RETR_TYPE_ACTIVE_PNR,
+            null
+        );
+
+        $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\Retrieve', $message);
+        /** @var Retrieve $message */
+        $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\Retrieve\RetrievalFacts', $message->retrievalFacts);
+        $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\Retrieve\Retrieve', $message->retrievalFacts->retrieve);
+        $this->assertEquals(Pnr\Retrieve::RETR_TYPE_ACTIVE_PNR, $message->retrievalFacts->retrieve->type);
+        $this->assertNull($message->retrievalFacts->reservationOrProfileIdentifier);
+
+        $this->assertNull($message->settings);
+    }
 }


### PR DESCRIPTION
I tested it and it works, but it is not usable for me 😢  However code is there, so maybe someone else will need it.

Btw, for future Amadeus explorers:
- Airline <controlNumber> is created after you save PNR and close the session...
- Same thing with reservation company, it is filled with IATA code only after session is closed.