### PR TITLE
MPTB Search - added layover per connection options

### DIFF
--- a/docs/samples/masterpricertravelboard.rst
+++ b/docs/samples/masterpricertravelboard.rst
@@ -908,3 +908,38 @@ Works only on return trip search.
             'returnTrip' => 20
         ])
     ]);
+
+Layover per connection
+============
+
+When itinerary consists of more than one segment, max layover per connection options narrows the search results by the specified hours and minutes value.
+
+.. code-block:: php
+
+    use Amadeus\Client\RequestOptions\FareMasterPricerTbSearch;
+    use Amadeus\Client\RequestOptions\Fare\MPItinerary;
+    use Amadeus\Client\RequestOptions\Fare\MPLocation;
+    use Amadeus\Client\RequestOptions\Fare\MasterPricer\MultiTicketWeights;
+    use Amadeus\Client\RequestOptionsFare\MPPassenger;
+    use Amadeus\Client\RequestOptionsFare\MPDate;
+
+    $opt = new FareMasterPricerTbSearch([
+        'nrOfRequestedPassengers' => 1,
+        'passengers' => [
+            new MPPassenger([
+                'type' => MPPassenger::TYPE_ADULT,
+                'count' => 1
+            ])
+        ],
+        'itinerary' => [
+            new MPItinerary([
+                'departureLocation' => new MPLocation(['city' => 'LON']),
+                'arrivalLocation' => new MPLocation(['city' => 'MOW']),
+                'date' => new MPDate([
+                    'dateTime' => new \DateTime('2018-05-05T00:00:00+0000', new \DateTimeZone('UTC'))
+                ])
+            ]),
+        ],
+        'maxLayoverPerConnectionHours' => 2,
+        'maxLayoverPerConnectionMinutes' => 30,
+    ]);

--- a/src/Amadeus/Client/RequestOptions/FareMasterPricerTbSearch.php
+++ b/src/Amadeus/Client/RequestOptions/FareMasterPricerTbSearch.php
@@ -167,4 +167,18 @@ class FareMasterPricerTbSearch extends MpBaseOptions
      * @var string
      */
     public $dkNumber;
+
+    /**
+     * Each connection of each requested segment has a layover limited to X hours.
+     *
+     * @var int
+     */
+    public $maxLayoverPerConnectionHours;
+
+    /**
+     * Each connection of each requested segment has a layover limited to Y minutes.
+     *
+     * @var int
+     */
+    public $maxLayoverPerConnectionMinutes;
 }

--- a/src/Amadeus/Client/Struct/Fare/MasterPricer/TravelFlightInfo.php
+++ b/src/Amadeus/Client/Struct/Fare/MasterPricer/TravelFlightInfo.php
@@ -64,6 +64,8 @@ class TravelFlightInfo extends WsMessageUtility
      * @param array|null $airlineOptions
      * @param int|null $progressiveLegsMin
      * @param int|null $progressiveLegsMax
+     * @param int|null $maxLayoverPerConnectionHours
+     * @param int|null $maxLayoverPerConnectionMinutes
      */
     public function __construct(
         $cabinCode = null,
@@ -71,7 +73,9 @@ class TravelFlightInfo extends WsMessageUtility
         $flightTypes = null,
         $airlineOptions = null,
         $progressiveLegsMin = null,
-        $progressiveLegsMax = null
+        $progressiveLegsMax = null,
+        $maxLayoverPerConnectionHours = null,
+        $maxLayoverPerConnectionMinutes = null
     ) {
         if (!is_null($cabinCode) || !is_null($cabinOption)) {
             $this->cabinId = new CabinId($cabinCode, $cabinOption);
@@ -98,6 +102,20 @@ class TravelFlightInfo extends WsMessageUtility
             $this->unitNumberDetail[] = new UnitNumberDetail(
                 $progressiveLegsMax,
                 UnitNumberDetail::TYPE_MAXIMUM_PROGRESSIVE_CONNECTIONS
+            );
+        }
+
+        if (is_int($maxLayoverPerConnectionHours)) {
+            $this->unitNumberDetail[] = new UnitNumberDetail(
+                $maxLayoverPerConnectionHours,
+                UnitNumberDetail::TYPE_MAX_LAYOVER_PER_CONNECTION_REQUESTED_SEGMENT_HOURS
+            );
+        }
+
+        if (is_int($maxLayoverPerConnectionMinutes)) {
+            $this->unitNumberDetail[] = new UnitNumberDetail(
+                $maxLayoverPerConnectionMinutes,
+                UnitNumberDetail::TYPE_MAX_LAYOVER_PER_CONNECTION_REQUESTED_SEGMENT_MINUTES
             );
         }
     }

--- a/src/Amadeus/Client/Struct/Fare/MasterPricerTravelBoardSearch.php
+++ b/src/Amadeus/Client/Struct/Fare/MasterPricerTravelBoardSearch.php
@@ -148,7 +148,9 @@ class MasterPricerTravelBoardSearch extends BaseMasterPricerMessage
             $options->requestedFlightTypes,
             $options->airlineOptions,
             $options->progressiveLegsMin,
-            $options->progressiveLegsMax
+            $options->progressiveLegsMax,
+            $options->maxLayoverPerConnectionHours,
+            $options->maxLayoverPerConnectionMinutes
         )) {
             $this->travelFlightInfo = new MasterPricer\TravelFlightInfo(
                 $options->cabinClass,
@@ -156,7 +158,9 @@ class MasterPricerTravelBoardSearch extends BaseMasterPricerMessage
                 $options->requestedFlightTypes,
                 $options->airlineOptions,
                 $options->progressiveLegsMin,
-                $options->progressiveLegsMax
+                $options->progressiveLegsMax,
+                $options->maxLayoverPerConnectionHours,
+                $options->maxLayoverPerConnectionMinutes
             );
         }
 

--- a/tests/Amadeus/Client/Struct/Fare/MasterPricerTravelBoardSearchTest.php
+++ b/tests/Amadeus/Client/Struct/Fare/MasterPricerTravelBoardSearchTest.php
@@ -1271,19 +1271,56 @@ class MasterPricerTravelBoardSearchTest extends BaseTestCase
 
         $this->assertEquals(1, $message->numberOfUnit->unitNumberDetail[0]->numberOfUnits);
         $this->assertEquals(UnitNumberDetail::TYPE_PASS, $message->numberOfUnit->unitNumberDetail[0]->typeOfUnit);
-        
+
         $this->assertEquals(200, $message->numberOfUnit->unitNumberDetail[1]->numberOfUnits);
         $this->assertEquals(UnitNumberDetail::TYPE_RESULTS, $message->numberOfUnit->unitNumberDetail[1]->typeOfUnit);
-        
+
         $this->assertEquals(30, $message->numberOfUnit->unitNumberDetail[2]->numberOfUnits);
         $this->assertEquals(UnitNumberDetail::TYPE_OUTBOUND_RECOMMENDATION, $message->numberOfUnit->unitNumberDetail[2]->typeOfUnit);
-        
+
         $this->assertEquals(20, $message->numberOfUnit->unitNumberDetail[3]->numberOfUnits);
         $this->assertEquals(UnitNumberDetail::TYPE_INBBOUND_RECOMMENDATION, $message->numberOfUnit->unitNumberDetail[3]->typeOfUnit);
-        
+
         $this->assertEquals(50, $message->numberOfUnit->unitNumberDetail[4]->numberOfUnits);
         $this->assertEquals(UnitNumberDetail::TYPE_COMPLETE_RECOMMENDATION, $message->numberOfUnit->unitNumberDetail[4]->typeOfUnit);
 
         $this->assertEquals("MTK", $message->fareOptions->pricingTickInfo->pricingTicketing->priceType[0]);
+    }
+
+    public function testCanMakeMessageWithLayoverPerConnectionOptions()
+    {
+        $opt = new FareMasterPricerTbSearch([
+            'nrOfRequestedPassengers' => 1,
+            'passengers' => [
+                new MPPassenger([
+                    'type' => MPPassenger::TYPE_ADULT,
+                    'count' => 1
+                ])
+            ],
+            'itinerary' => [
+                new MPItinerary([
+                    'departureLocation' => new MPLocation(['city' => 'IST']),
+                    'arrivalLocation' => new MPLocation(['city' => 'LON']),
+                    'date' => new MPDate([
+                        'dateTime' => new \DateTime('2018-05-05T00:00:00+0000', new \DateTimeZone('UTC'))
+                    ])
+                ]),
+            ],
+            'maxLayoverPerConnectionHours' => 2,
+            'maxLayoverPerConnectionMinutes' => 30,
+        ]);
+
+        $message = new MasterPricerTravelBoardSearch($opt);
+
+        foreach ($message->travelFlightInfo->unitNumberDetail as $unitNumberDetail) {
+            switch ($unitNumberDetail->typeOfUnit) {
+                case UnitNumberDetail::TYPE_MAX_LAYOVER_PER_CONNECTION_REQUESTED_SEGMENT_HOURS:
+                    $this->assertEquals(2, $unitNumberDetail->numberOfUnits);
+                    break;
+                case UnitNumberDetail::TYPE_MAX_LAYOVER_PER_CONNECTION_REQUESTED_SEGMENT_MINUTES:
+                    $this->assertEquals(30, $unitNumberDetail->numberOfUnits);
+                    break;
+            }
+        }
     }
 }


### PR DESCRIPTION
Added extra options for `Fare_MasterPricerTravelBoardSearch`.

From extranet:

> The user can request a maximum layover per connection (in hours and in minutes).
> Each connection of each requested segment has a layover limited to X hours and Y minutes.