### PR TITLE
FOP_CreateFormOfPayment allow sequence number 0

### DIFF
--- a/src/Amadeus/Client/Struct/Fop/MopDescription.php
+++ b/src/Amadeus/Client/Struct/Fop/MopDescription.php
@@ -61,7 +61,7 @@ class MopDescription extends WsMessageUtility
      */
     public function __construct(MopInfo $options)
     {
-        if (!empty($options->sequenceNr)) {
+        if (isset($options->sequenceNr)) {
             $this->fopSequenceNumber = new FopSequenceNumber($options->sequenceNr);
         }
 

--- a/src/Amadeus/Client/Struct/Fop/MopDescription.php
+++ b/src/Amadeus/Client/Struct/Fop/MopDescription.php
@@ -61,7 +61,7 @@ class MopDescription extends WsMessageUtility
      */
     public function __construct(MopInfo $options)
     {
-        if (isset($options->sequenceNr)) {
+        if (!is_null($options->sequenceNr)) {
             $this->fopSequenceNumber = new FopSequenceNumber($options->sequenceNr);
         }
 


### PR DESCRIPTION
Fop sequence number check must be changed, because `empty()` method returns `false`, when `$sequenceNr = 0`.
It breaks the struct when trying to add a form of payment (FP) element including both old and new forms of payment where old must have 0 sequence number 
(First example on FOP_CreateFormOfPayment examples page at extranet)

```
<fopSequenceNumber>
    <sequenceDetails>
        <number>0</number>
    </sequenceDetails>
</fopSequenceNumber>
```