### PR TITLE
Fix double authentication when calling Security_Authenticate with SoapHeader 4

### DIFF
--- a/src/Amadeus/Client/Session/Handler/SoapHeader4.php
+++ b/src/Amadeus/Client/Session/Handler/SoapHeader4.php
@@ -285,84 +285,81 @@ class SoapHeader4 extends Base
             );
         }
 
-        // If not Security_Authenticate message - send authentication information in headers
-        if ($this->isNotSecurityAuthenticateMessage($messageName)) {
-            //Send authentication info
-            if ($this->isAuthenticated === false) {
-                //Generate nonce, msg creation string & password digest:
-                $password = base64_decode($params->authParams->passwordData);
-                $creation = new \DateTime('now', new \DateTimeZone('UTC'));
-                $t = microtime(true);
-                $micro = sprintf("%03d", ($t - floor($t)) * 1000);
-                $creationString = $this->createDateTimeStringForAuth($creation, $micro);
-                $messageNonce = $this->generateUniqueNonce($params->authParams->nonceBase, $creationString);
-                $encodedNonce = base64_encode($messageNonce);
-                $digest = $this->generatePasswordDigest($password, $creationString, $messageNonce);
+        //Send authentication info headers if not authenticated and not Security_Authenticate message call
+        if ($this->isAuthenticated === false && $this->isNotSecurityAuthenticateMessage($messageName)) {
+            //Generate nonce, msg creation string & password digest:
+            $password = base64_decode($params->authParams->passwordData);
+            $creation = new \DateTime('now', new \DateTimeZone('UTC'));
+            $t = microtime(true);
+            $micro = sprintf("%03d", ($t - floor($t)) * 1000);
+            $creationString = $this->createDateTimeStringForAuth($creation, $micro);
+            $messageNonce = $this->generateUniqueNonce($params->authParams->nonceBase, $creationString);
+            $encodedNonce = base64_encode($messageNonce);
+            $digest = $this->generatePasswordDigest($password, $creationString, $messageNonce);
 
-                $securityHeaderXml = $this->generateSecurityHeaderRawXml(
-                    $params->authParams->userId,
-                    $encodedNonce,
-                    $digest,
-                    $creationString
-                );
+            $securityHeaderXml = $this->generateSecurityHeaderRawXml(
+                $params->authParams->userId,
+                $encodedNonce,
+                $digest,
+                $creationString
+            );
 
-                //Authentication header
-                array_push(
-                    $headersToSet,
-                    new \SoapHeader(
-                        'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wsswssecurity-secext-1.0.xsd',
-                        'Security',
-                        new \SoapVar($securityHeaderXml, XSD_ANYXML)
-                    )
-                );
+            //Authentication header
+            array_push(
+                $headersToSet,
+                new \SoapHeader(
+                    'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wsswssecurity-secext-1.0.xsd',
+                    'Security',
+                    new \SoapVar($securityHeaderXml, XSD_ANYXML)
+                )
+            );
 
-                if ($stateful === true) {
-                    //Not authenticated but stateful: start session!
-                    array_push(
-                        $headersToSet,
-                        new \SoapHeader(
-                            'http://xml.amadeus.com/2010/06/Session_v3',
-                            'Session',
-                            new Client\Struct\HeaderV4\Session(
-                                null,
-                                "Start"
-                            )
-                        )
-                    );
-                }
-
-                //AMA_SecurityHostedUser header
-                array_push(
-                    $headersToSet,
-                    new \SoapHeader(
-                        'http://xml.amadeus.com/2010/06/Security_v1',
-                        'AMA_SecurityHostedUser',
-                        new Client\Struct\HeaderV4\SecurityHostedUser(
-                            $params->authParams->officeId,
-                            $params->authParams->originatorTypeCode,
-                            1,
-                            $params->authParams->dutyCode
-                        )
-                    )
-                );
-            } elseif ($stateful === true) {
-                //We are authenticated and stateful: provide session header to continue or terminate session
-                $statusCode =
-                    (isset($messageOptions['endSession']) && $messageOptions['endSession'] === true) ?
-                        "End" : "InSeries";
-
+            if ($stateful === true) {
+                //Not authenticated but stateful: start session!
                 array_push(
                     $headersToSet,
                     new \SoapHeader(
                         'http://xml.amadeus.com/2010/06/Session_v3',
                         'Session',
                         new Client\Struct\HeaderV4\Session(
-                            $sessionData,
-                            $statusCode
+                            null,
+                            "Start"
                         )
                     )
                 );
             }
+
+            //AMA_SecurityHostedUser header
+            array_push(
+                $headersToSet,
+                new \SoapHeader(
+                    'http://xml.amadeus.com/2010/06/Security_v1',
+                    'AMA_SecurityHostedUser',
+                    new Client\Struct\HeaderV4\SecurityHostedUser(
+                        $params->authParams->officeId,
+                        $params->authParams->originatorTypeCode,
+                        1,
+                        $params->authParams->dutyCode
+                    )
+                )
+            );
+        } elseif ($stateful === true) {
+            //We are authenticated and stateful: provide session header to continue or terminate session
+            $statusCode =
+                (isset($messageOptions['endSession']) && $messageOptions['endSession'] === true) ?
+                    "End" : "InSeries";
+
+            array_push(
+                $headersToSet,
+                new \SoapHeader(
+                    'http://xml.amadeus.com/2010/06/Session_v3',
+                    'Session',
+                    new Client\Struct\HeaderV4\Session(
+                        $sessionData,
+                        $statusCode
+                    )
+                )
+            );
         }
 
         return $headersToSet;
@@ -415,11 +412,11 @@ class SoapHeader4 extends Base
         $charId = strtoupper(md5(uniqid(rand(), true)));
         $hyphen = chr(45); // "-"
 
-        $uuid = substr($charId, 0, 8).$hyphen
-            .substr($charId, 8, 4).$hyphen
-            .substr($charId, 12, 4).$hyphen
-            .substr($charId, 16, 4).$hyphen
-            .substr($charId, 20, 12);
+        $uuid = substr($charId, 0, 8) . $hyphen
+            . substr($charId, 8, 4) . $hyphen
+            . substr($charId, 12, 4) . $hyphen
+            . substr($charId, 16, 4) . $hyphen
+            . substr($charId, 20, 12);
 
         return $uuid;
     }
@@ -493,6 +490,7 @@ class SoapHeader4 extends Base
     protected function createDateTimeStringForAuth($creationDateTime, $micro)
     {
         $creationDateTime->setTimezone(new \DateTimeZone('UTC'));
+
         return $creationDateTime->format("Y-m-d\TH:i:s:") . $micro . 'Z';
     }
 

--- a/src/Amadeus/Client/Struct/Security/PasswordInfo.php
+++ b/src/Amadeus/Client/Struct/Security/PasswordInfo.php
@@ -35,6 +35,7 @@ class PasswordInfo
      *
      * See Amadeus Core Webservices documentation
      * [DATA TYPE codesets (Ref: 116Z 1A 02.1.8)]
+     *
      * @var string
      */
     const DATA_TYPE_EDIFACT = 'E';
@@ -43,9 +44,22 @@ class PasswordInfo
      *
      * See Amadeus Core Webservices documentation
      * [DATA TYPE codesets (Ref: 116Z 1A 02.1.8)]
+     *
      * @var string
      */
     const DATA_TYPE_BINARY = 'B';
+    /**
+     * When using "EDIFACT DATA" type, password length value must be 12.
+     *
+     * @var int
+     */
+    const PASSWORD_LENGTH_EDIFACT = 12;
+    /**
+     * When using "BINARY DATA" type, password length value must be 40.
+     *
+     * @var int
+     */
+    const PASSWORD_LENGTH_BINARY = 40;
 
     /**
      * @var int
@@ -67,8 +81,11 @@ class PasswordInfo
      * @param int $passwordLength
      * @param string $type
      */
-    public function __construct($passwordData, $passwordLength, $type = self::DATA_TYPE_EDIFACT)
-    {
+    public function __construct(
+        $passwordData,
+        $passwordLength = self::PASSWORD_LENGTH_EDIFACT,
+        $type = self::DATA_TYPE_EDIFACT
+    ) {
         $this->binaryData = $passwordData;
         $this->dataLength = $passwordLength;
         $this->dataType = $type;


### PR DESCRIPTION
I know that is not urgent at all, but I had some free time and desire to fix it. #151 

Personally I am a little confused with `if` statement that will check message name on every call, but maybe I'm too worried.

In any case, maybe @DerMika  have any idea of how this could be solved in other way?