### PR TITLE
MasterPricer trip details

### DIFF
--- a/docs/samples/masterpricertravelboard.rst
+++ b/docs/samples/masterpricertravelboard.rst
@@ -20,7 +20,6 @@ Maximum 30 recommendations:
     use Amadeus\Client\RequestOptions\Fare\MPLocation;
     use Amadeus\Client\RequestOptions\Fare\MPPassenger;
     use Amadeus\Client\RequestOptions\Fare\MPDate;
-    use Amadeus\Client\RequestOptions\Fare\MPTripDetails;
 
     $opt = new FareMasterPricerTbSearch([
         'nrOfRequestedResults' => 30,
@@ -53,10 +52,7 @@ Maximum 30 recommendations:
                     'dateTime' => new \DateTime('2017-03-12T18:00:00+0000', new \DateTimeZone('UTC')),
                     'timeWindow' => 5,
                     'rangeMode' => MPDate::RANGEMODE_PLUS,
-                    'range' => 1,
-                    'tripDetails' => new MPTripDetails([
-                        'flexibilityQualifier' => MPTripDetails::FLEXIBILITY_COMBINED
-                    ])
+                    'range' => 1
                 ])
             ])
         ]

--- a/docs/samples/masterpricertravelboard.rst
+++ b/docs/samples/masterpricertravelboard.rst
@@ -20,6 +20,7 @@ Maximum 30 recommendations:
     use Amadeus\Client\RequestOptions\Fare\MPLocation;
     use Amadeus\Client\RequestOptions\Fare\MPPassenger;
     use Amadeus\Client\RequestOptions\Fare\MPDate;
+    use Amadeus\Client\RequestOptions\Fare\MPTripDetails;
 
     $opt = new FareMasterPricerTbSearch([
         'nrOfRequestedResults' => 30,
@@ -52,44 +53,9 @@ Maximum 30 recommendations:
                     'dateTime' => new \DateTime('2017-03-12T18:00:00+0000', new \DateTimeZone('UTC')),
                     'timeWindow' => 5,
                     'rangeMode' => MPDate::RANGEMODE_PLUS,
-                    'range' => 1
-                ])
-            ])
-        ]
-    ]);
-
-MasterPricerCalendar flexible trip details
-==========================================
-
-Kiev - New York one way with 1 adult.
-Flexible with the outbound date, but want to travel exactly 7 days.
-
-.. code-block:: php
-
-    use Amadeus\Client\RequestOptions\FareMasterPricerTbSearch;
-    use Amadeus\Client\RequestOptions\Fare\MPItinerary;
-    use Amadeus\Client\RequestOptions\Fare\MPLocation;
-    use Amadeus\Client\RequestOptions\Fare\MPPassenger;
-    use Amadeus\Client\RequestOptions\Fare\MPDate;
-    use Amadeus\Client\RequestOptions\Fare\MPTripDetails;
-
-    $opt = new FareMasterPricerCalendarOptions([
-        'nrOfRequestedPassengers' => 1,
-        'passengers' => [
-            new MPPassenger([
-                'type' => MPPassenger::TYPE_ADULT,
-                'count' => 1
-            ])
-        ],
-        'itinerary' => [
-            new MPItinerary([
-                'departureLocation' => new MPLocation(['city' => 'KBP']),
-                'arrivalLocation' => new MPLocation(['city' => 'JFK']),
-                'date' => new MPDate([
+                    'range' => 1,
                     'tripDetails' => new MPTripDetails([
-                        'flexibilityQualifier' => MPTripDetails::FLEXIBILITY_COMBINED,
-                        'tripInterval' => 1,
-                        'tripDuration' => 7
+                        'flexibilityQualifier' => MPTripDetails::FLEXIBILITY_COMBINED
                     ])
                 ])
             ])

--- a/docs/samples/masterpricertravelboard.rst
+++ b/docs/samples/masterpricertravelboard.rst
@@ -58,6 +58,45 @@ Maximum 30 recommendations:
         ]
     ]);
 
+MasterPricerCalendar flexible trip details
+==============================================
+
+If you ara flexible with the outbound date, but want to travel exactly 7 days.
+Kiev - New York one way with 1 adult.
+Flexible with the outbound date, but want to travel exactly 7 days.
+
+.. code-block:: php
+
+    use Amadeus\Client\RequestOptions\FareMasterPricerTbSearch;
+    use Amadeus\Client\RequestOptions\Fare\MPItinerary;
+    use Amadeus\Client\RequestOptions\Fare\MPLocation;
+    use Amadeus\Client\RequestOptions\Fare\MPPassenger;
+    use Amadeus\Client\RequestOptions\Fare\MPDate;
+    use Amadeus\Client\RequestOptions\Fare\MPTripDetails;
+
+    $opt = new FareMasterPricerCalendarOptions([
+        'nrOfRequestedPassengers' => 1,
+        'passengers' => [
+            new MPPassenger([
+                'type' => MPPassenger::TYPE_ADULT,
+                'count' => 1
+            ])
+        ],
+        'itinerary' => [
+            new MPItinerary([
+                'departureLocation' => new MPLocation(['city' => 'KBP']),
+                'arrivalLocation' => new MPLocation(['city' => 'JFK']),
+                'date' => new MPDate([
+                    'tripDetails' => new MPTripDetails([
+                        'flexibilityQualifier' => MPTripDetails::FLEXIBILITY_COMBINED,
+                        'tripInterval' => 1,
+                        'tripDuration' => 7
+                    ])
+                ])
+            ])
+        ]
+    ]);
+
 Currency conversion
 ===================
 

--- a/docs/samples/masterpricertravelboard.rst
+++ b/docs/samples/masterpricertravelboard.rst
@@ -59,9 +59,8 @@ Maximum 30 recommendations:
     ]);
 
 MasterPricerCalendar flexible trip details
-==============================================
+==========================================
 
-If you ara flexible with the outbound date, but want to travel exactly 7 days.
 Kiev - New York one way with 1 adult.
 Flexible with the outbound date, but want to travel exactly 7 days.
 

--- a/src/Amadeus/Client/RequestOptions/Fare/MPDate.php
+++ b/src/Amadeus/Client/RequestOptions/Fare/MPDate.php
@@ -101,4 +101,11 @@ class MPDate extends LoadParamsFromArray
      * @var int
      */
     public $range;
+
+    /**
+     * Details of the trip duration
+     *
+     * @var MPTripDetails
+     */
+    public $tripDetails;
 }

--- a/src/Amadeus/Client/RequestOptions/Fare/MPDate.php
+++ b/src/Amadeus/Client/RequestOptions/Fare/MPDate.php
@@ -103,7 +103,9 @@ class MPDate extends LoadParamsFromArray
     public $range;
 
     /**
-     * Details of the trip duration
+     * Details of the trip duration.
+     *
+     * Amadeus currently not uses this node, but may be used in future versions.
      *
      * @var MPTripDetails
      */

--- a/src/Amadeus/Client/RequestOptions/Fare/MPTripDetails.php
+++ b/src/Amadeus/Client/RequestOptions/Fare/MPTripDetails.php
@@ -48,13 +48,15 @@ class MPTripDetails extends LoadParamsFromArray
     public $flexibilityQualifier;
 
     /**
-     * A date that applies to a means of transport or a traveller.
+     * Number of days added or/and retrieved to the trip duration.
      *
      * @var int
      */
     public $tripInterval;
 
     /**
+     * Period between date of departure and date of arrival.
+     *
      * @var int
      */
     public $tripDuration;

--- a/src/Amadeus/Client/RequestOptions/Fare/MPTripDetails.php
+++ b/src/Amadeus/Client/RequestOptions/Fare/MPTripDetails.php
@@ -20,24 +20,36 @@
  * @license https://opensource.org/licenses/Apache-2.0 Apache 2.0
  */
 
-namespace Amadeus\Client\Struct\Fare\MasterPricer;
+namespace Amadeus\Client\RequestOptions\Fare;
 
-use Amadeus\Client\RequestOptions\Fare\MPTripDetails;
+use Amadeus\Client\LoadParamsFromArray;
 
 /**
- * TripDetails
+ * MPTripDetails
  *
- * @package Amadeus\Client\Struct\Fare\MasterPricer
- * @author Dieter Devlieghere <dermikagh@gmail.com>
+ * Details of the trip duration
+ *
+ * @package Amadeus\Client\RequestOptions\Fare
+ * @author Artem Zakharchenko <artz.relax@gmail.com>
  */
-class TripDetails
+class MPTripDetails extends LoadParamsFromArray
 {
+    const FLEXIBILITY_COMBINED = 'C';
+    const FLEXIBILITY_MINUS = 'M';
+    const FLEXIBILITY_PLUS = 'P';
+    const FLEXIBILITY_ARRIVAL_BY = 'TA';
+    const FLEXIBILITY_DEPART_FROM = 'TD';
+
     /**
+     * self::FLEXIBILITY_*
+     *
      * @var string
      */
     public $flexibilityQualifier;
 
     /**
+     * A date that applies to a means of transport or a traveller.
+     *
      * @var int
      */
     public $tripInterval;
@@ -46,16 +58,4 @@ class TripDetails
      * @var int
      */
     public $tripDuration;
-
-    /**
-     * TripDetails constructor.
-     *
-     * @param MPTripDetails $tripDetails
-     */
-    public function __construct(MPTripDetails $tripDetails)
-    {
-        $this->flexibilityQualifier = $tripDetails->flexibilityQualifier;
-        $this->tripInterval = $tripDetails->tripInterval;
-        $this->tripDuration = $tripDetails->tripDuration;
-    }
 }

--- a/src/Amadeus/Client/Struct/Fare/MasterPricer/TimeDetails.php
+++ b/src/Amadeus/Client/Struct/Fare/MasterPricer/TimeDetails.php
@@ -23,6 +23,7 @@
 namespace Amadeus\Client\Struct\Fare\MasterPricer;
 
 use Amadeus\Client\RequestOptions\Fare\MPDate;
+use Amadeus\Client\RequestOptions\Fare\MPTripDetails;
 
 /**
  * TimeDetails
@@ -76,6 +77,10 @@ class TimeDetails
                 $theDate->rangeMode,
                 $theDate->range
             );
+        }
+
+        if (!is_null($theDate->tripDetails) && $theDate->tripDetails instanceof MPTripDetails) {
+            $this->tripDetails = new TripDetails($theDate->tripDetails);
         }
     }
 

--- a/src/Amadeus/Client/Struct/Fare/MasterPricer/TripDetails.php
+++ b/src/Amadeus/Client/Struct/Fare/MasterPricer/TripDetails.php
@@ -27,6 +27,8 @@ use Amadeus\Client\RequestOptions\Fare\MPTripDetails;
 /**
  * TripDetails
  *
+ * Amadeus currently not uses this node, but may be used in future versions.
+ *
  * @package Amadeus\Client\Struct\Fare\MasterPricer
  * @author Dieter Devlieghere <dermikagh@gmail.com>
  */

--- a/src/Amadeus/Client/Struct/Fare/MasterPricer/TripDetails.php
+++ b/src/Amadeus/Client/Struct/Fare/MasterPricer/TripDetails.php
@@ -34,6 +34,12 @@ use Amadeus\Client\RequestOptions\Fare\MPTripDetails;
  */
 class TripDetails
 {
+    const FLEXIBILITY_COMBINED = 'C';
+    const FLEXIBILITY_MINUS = 'M';
+    const FLEXIBILITY_PLUS = 'P';
+    const FLEXIBILITY_ARRIVAL_BY = 'TA';
+    const FLEXIBILITY_DEPART_FROM = 'TD';
+
     /**
      * @var string
      */

--- a/tests/Amadeus/Client/Struct/Fare/MasterPricer/TripDetailsTest.php
+++ b/tests/Amadeus/Client/Struct/Fare/MasterPricer/TripDetailsTest.php
@@ -39,7 +39,7 @@ class TripDetailsTest extends BaseTestCase
         $requestOptions = new MPTripDetails([
             'flexibilityQualifier' => MPTripDetails::FLEXIBILITY_COMBINED,
             'tripInterval' => 1,
-            'tripDuration' => 7
+            'tripDuration' => 3
         ]);
 
         $tripDetails = new TripDetails($requestOptions);

--- a/tests/Amadeus/Client/Struct/Fare/MasterPricer/TripDetailsTest.php
+++ b/tests/Amadeus/Client/Struct/Fare/MasterPricer/TripDetailsTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * amadeus-ws-client
+ *
+ * Copyright 2015 Amadeus Benelux NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @package Amadeus
+ * @license https://opensource.org/licenses/Apache-2.0 Apache 2.0
+ */
+
+namespace Test\Amadeus\Client\Struct\Fare\MasterPricer;
+
+use Amadeus\Client\RequestOptions\Fare\MPTripDetails;
+use Amadeus\Client\Struct\Fare\MasterPricer\TripDetails;
+use Test\Amadeus\BaseTestCase;
+
+/**
+ * TripDetailsTest
+ *
+ * @package Test\Amadeus\Client\Struct\Fare\MasterPricer
+ * @author Artem Zakharchenko <artz.relax@gmail.com>
+ */
+class TripDetailsTest extends BaseTestCase
+{
+    public function testCanCreateFromRequestOptions()
+    {
+        $requestOptions = new MPTripDetails([
+            'flexibilityQualifier' => MPTripDetails::FLEXIBILITY_COMBINED,
+            'tripInterval' => 1,
+            'tripDuration' => 7
+        ]);
+
+        $tripDetails = new TripDetails($requestOptions);
+
+        $this->assertEquals($requestOptions->flexibilityQualifier, $tripDetails->flexibilityQualifier);
+        $this->assertEquals($requestOptions->tripInterval, $tripDetails->tripInterval);
+        $this->assertEquals($requestOptions->tripDuration, $tripDetails->tripDuration);
+    }
+}

--- a/tests/Amadeus/Client/Struct/Fare/MasterPricerCalendarTest.php
+++ b/tests/Amadeus/Client/Struct/Fare/MasterPricerCalendarTest.php
@@ -126,10 +126,11 @@ class MasterPricerCalendarTest extends BaseTestCase
                     'departureLocation' => new MPLocation(['city' => 'KBP']),
                     'arrivalLocation' => new MPLocation(['city' => 'JFK']),
                     'date' => new MPDate([
+                        'date' => new \DateTime('2018-11-16T00:00:00+0000', new \DateTimeZone('UTC')),
+                        'rangeMode' => MPDate::RANGEMODE_MINUS_PLUS,
+                        'range' => 3,
                         'tripDetails' => new MPTripDetails([
                             'flexibilityQualifier' => MPTripDetails::FLEXIBILITY_COMBINED,
-                            'tripInterval' => 1,
-                            'tripDuration' => 7
                         ])
                     ])
                 ])
@@ -151,8 +152,9 @@ class MasterPricerCalendarTest extends BaseTestCase
         $this->assertEquals('KBP', $message->itinerary[0]->departureLocalization->departurePoint->locationId);
         $this->assertEquals('JFK', $message->itinerary[0]->arrivalLocalization->arrivalPointDetails->locationId);
 
+        $this->assertEquals('161118', $message->itinerary[0]->timeDetails->firstDateTimeDetail->date);
+        $this->assertEquals(3, $message->itinerary[0]->timeDetails->rangeOfDate->dayInterval);
+        $this->assertEquals(RangeOfDate::RANGEMODE_MINUS_PLUS, $message->itinerary[0]->timeDetails->rangeOfDate->rangeQualifier);
         $this->assertEquals(MPTripDetails::FLEXIBILITY_COMBINED, $message->itinerary[0]->timeDetails->tripDetails->flexibilityQualifier);
-        $this->assertEquals(1, $message->itinerary[0]->timeDetails->tripDetails->tripInterval);
-        $this->assertEquals(7, $message->itinerary[0]->timeDetails->tripDetails->tripDuration);
     }
 }

--- a/tests/Amadeus/Client/Struct/Fare/MasterPricerCalendarTest.php
+++ b/tests/Amadeus/Client/Struct/Fare/MasterPricerCalendarTest.php
@@ -110,6 +110,8 @@ class MasterPricerCalendarTest extends BaseTestCase
 
     /**
      * Test creating itinerary/timeDetails/tripDetails.
+     *
+     * Amadeus currently not uses this node, but may be used in future versions.
      */
     public function testCanMakeRequestWithTripDetails()
     {

--- a/tests/Amadeus/Client/Struct/Fare/MasterPricerCalendarTest.php
+++ b/tests/Amadeus/Client/Struct/Fare/MasterPricerCalendarTest.php
@@ -29,6 +29,7 @@ use Amadeus\Client\RequestOptions\Fare\MPPassenger;
 use Amadeus\Client\RequestOptions\Fare\MPTripDetails;
 use Amadeus\Client\RequestOptions\FareMasterPricerCalendarOptions;
 use Amadeus\Client\Struct\Fare\MasterPricer\RangeOfDate;
+use Amadeus\Client\Struct\Fare\MasterPricer\TripDetails;
 use Amadeus\Client\Struct\Fare\MasterPricer\UnitNumberDetail;
 use Amadeus\Client\Struct\Fare\MasterPricerCalendar;
 use Test\Amadeus\BaseTestCase;
@@ -157,6 +158,6 @@ class MasterPricerCalendarTest extends BaseTestCase
         $this->assertEquals('161118', $message->itinerary[0]->timeDetails->firstDateTimeDetail->date);
         $this->assertEquals(3, $message->itinerary[0]->timeDetails->rangeOfDate->dayInterval);
         $this->assertEquals(RangeOfDate::RANGEMODE_MINUS_PLUS, $message->itinerary[0]->timeDetails->rangeOfDate->rangeQualifier);
-        $this->assertEquals(MPTripDetails::FLEXIBILITY_COMBINED, $message->itinerary[0]->timeDetails->tripDetails->flexibilityQualifier);
+        $this->assertEquals(TripDetails::FLEXIBILITY_COMBINED, $message->itinerary[0]->timeDetails->tripDetails->flexibilityQualifier);
     }
 }


### PR DESCRIPTION
Enhancement for MasterPricerCalendar message.

Resolves #259 

**WIP** - Need to test manually, that XML are generating as expected:

```
<timeDetails>
    <tripDetails>
        <flexibilityQualifier>C</flexibilityQualifier>
        <tripInterval>1</tripInterval>
        <tripDuration>7</tripDuration>
    </tripDetails>
</timeDetails>
```

I'll test soon and update PR.

UPD: Message XML generated correctly, but I get error response from Amadeus with message "Invalid trip duration option". I guess it depends on office settings, but I ask Amadeus Support and wait for their reply.

UPD2: Amadeus currently not uses this node, but may be used in future versions.