### PR TITLE
Master Pricer: Form of Payment

### DIFF
--- a/docs/samples/masterpricertravelboard.rst
+++ b/docs/samples/masterpricertravelboard.rst
@@ -1232,7 +1232,7 @@ The following sample disallows airport changes for the outbound leg:
     ]);
 
 Ticketing Price Scheme
-==================================
+======================
 
 When needed to impose an additional Service Fee to the customer add PSR number (Price Scheme Reference):
 
@@ -1265,5 +1265,46 @@ When needed to impose an additional Service Fee to the customer add PSR number (
         'ticketingPriceScheme' => new MPTicketingPriceScheme([
             'referenceNumber' => '00012345'
         ])
+    ]);
+
+Form of Payment
+==================================
+
+The form of payment option may be combined with any other option. A maximum of 3 forms of payment may be specified in.
+See all available type codes in `Amadeus\Client\RequestOptions\Fare\MasterPricer\FormOfPaymentDetails` class or Amadeus Extranet docs.
+
+.. code-block:: php
+
+    use Amadeus\Client\RequestOptions\FareMasterPricerTbSearch;
+    use Amadeus\Client\RequestOptions\Fare\MPItinerary;
+    use Amadeus\Client\RequestOptions\Fare\MPLocation;
+    use Amadeus\Client\RequestOptions\Fare\MPPassenger;
+    use Amadeus\Client\RequestOptions\Fare\MPDate;
+    use Amadeus\Client\RequestOptions\Fare\MasterPricer\FormOfPaymentDetails;
+
+    $opt = new FareMasterPricerTbSearch([
+        'nrOfRequestedPassengers' => 1,
+        'passengers' => [
+            new MPPassenger([
+                'type' => MPPassenger::TYPE_ADULT,
+                'count' => 1
+            ])
+        ],
+        'itinerary' => [
+            new MPItinerary([
+                'departureLocation' => new MPLocation(['city' => 'NYC']),
+                'arrivalLocation' => new MPLocation(['city' => 'LAX']),
+                'date' => new MPDate([
+                    'dateTime' => new \DateTime('2018-07-05T00:00:00+0000', new \DateTimeZone('UTC'))
+                ]),
+            ]),
+        ],
+        'formOfPayment' => [
+            new FormOfPaymentDetails([
+                'type' => FormOfPaymentDetails::TYPE_CREDIT_CARD,
+                'chargedAmount' => 100,
+                'creditCardNumber' => '123456'
+            ])
+        ]
     ]);
 

--- a/src/Amadeus/Client/RequestOptions/Fare/MasterPricer/FormOfPaymentDetails.php
+++ b/src/Amadeus/Client/RequestOptions/Fare/MasterPricer/FormOfPaymentDetails.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * amadeus-ws-client
+ *
+ * Copyright 2015 Amadeus Benelux NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @package Amadeus
+ * @license https://opensource.org/licenses/Apache-2.0 Apache 2.0
+ */
+
+namespace Amadeus\Client\RequestOptions\Fare\MasterPricer;
+
+use Amadeus\Client\LoadParamsFromArray;
+
+/**
+ * FormOfPaymentDetails
+ *
+ * @package Amadeus\Client\RequestOptions\Fare\MasterPricer
+ * @author Artem Zakharchenko <artz.relax@gmail.com>
+ */
+class FormOfPaymentDetails extends LoadParamsFromArray
+{
+    const TYPE_BEHALF_EXCHANGE = 'AGT';
+    const TYPE_CASH = 'CA';
+    const TYPE_CREDIT_CARD = 'CC';
+    const TYPE_CHECK = 'CK';
+    const TYPE_GOVERNMENT_TRANSPORTATION_REQUEST = 'GR';
+    const TYPE_MISCELLANEOUS = 'MS';
+    const TYPE_NON_REFUNDABLE = 'NR';
+    const TYPE_PREPAID_TICKET_ADVICE = 'PT';
+    const TYPE_SINGLE_GOVERNMENT_TRANSPORTATION_REQUEST = 'SGR';
+    const TYPE_UNITED_NATIONS_TRANSPORTATION_REQUEST = 'UN';
+
+    /**
+     * Identification of a form of payment type.
+     *
+     * @var string
+     */
+    public $type;
+
+    /**
+     * Number of monetary units.
+     *
+     * @var int|float|string|null
+     */
+    public $chargedAmount;
+
+    /**
+     * Identification number.
+     *
+     * @var string
+     */
+    public $creditCardNumber;
+}

--- a/src/Amadeus/Client/RequestOptions/Fare/MasterPricer/FormOfPaymentDetails.php
+++ b/src/Amadeus/Client/RequestOptions/Fare/MasterPricer/FormOfPaymentDetails.php
@@ -46,6 +46,8 @@ class FormOfPaymentDetails extends LoadParamsFromArray
     /**
      * Identification of a form of payment type.
      *
+     * self::TYPE_*
+     *
      * @var string
      */
     public $type;

--- a/src/Amadeus/Client/RequestOptions/MpBaseOptions.php
+++ b/src/Amadeus/Client/RequestOptions/MpBaseOptions.php
@@ -134,7 +134,7 @@ class MpBaseOptions extends Base
      * @var Fare\MPFeeId[]
      */
     public $feeIds;
-    
+
     /**
      * Whether to perform a multi ticket search
      *
@@ -153,4 +153,11 @@ class MpBaseOptions extends Base
      * @var Fare\MasterPricer\MultiTicketWeights
      */
     public $multiTicketWeights;
+
+    /**
+     * A maximum of 3 forms of payment may be specified.
+     *
+     * @var Fare\MasterPricer\FormOfPaymentDetails[]|array
+     */
+    public $formOfPayment;
 }

--- a/src/Amadeus/Client/Struct/Fare/BaseMasterPricerMessage.php
+++ b/src/Amadeus/Client/Struct/Fare/BaseMasterPricerMessage.php
@@ -99,7 +99,10 @@ class BaseMasterPricerMessage extends BaseWsMessage
      */
     protected function loadNumberOfUnits($options)
     {
-        if (is_int($options->nrOfRequestedPassengers) || is_int($options->nrOfRequestedResults) || $options->multiTicketWeights instanceof MultiTicketWeights) {
+        if (is_int($options->nrOfRequestedPassengers) ||
+            is_int($options->nrOfRequestedResults) ||
+            $options->multiTicketWeights instanceof MultiTicketWeights
+        ) {
             $this->numberOfUnit = new MasterPricer\NumberOfUnit(
                 $options->nrOfRequestedPassengers,
                 $options->nrOfRequestedResults,
@@ -120,7 +123,8 @@ class BaseMasterPricerMessage extends BaseWsMessage
                 $options->currencyOverride,
                 $options->feeIds,
                 $options->multiTicket,
-                $options->ticketingPriceScheme
+                $options->ticketingPriceScheme,
+                $options->formOfPayment
             )
         ) {
             $this->fareOptions = new MasterPricer\FareOptions(
@@ -131,7 +135,8 @@ class BaseMasterPricerMessage extends BaseWsMessage
                 $options->feeIds,
                 $options->corporateQualifier,
                 $options->multiTicket,
-                $options->ticketingPriceScheme
+                $options->ticketingPriceScheme,
+                $options->formOfPayment
             );
         }
     }

--- a/src/Amadeus/Client/Struct/Fare/MasterPricer/FareOptions.php
+++ b/src/Amadeus/Client/Struct/Fare/MasterPricer/FareOptions.php
@@ -53,7 +53,9 @@ class FareOptions
      * @var ConversionRate
      */
     public $conversionRate;
-
+    /**
+     * @var FormOfPaymentDetails[]|array
+     */
     public $formOfPayment;
 
     public $frequentTravellerInfo;
@@ -73,6 +75,7 @@ class FareOptions
      * @param string|null Corporate qualifier for Corporate Unifares
      * @param $multiTicket
      * @param MPTicketingPriceScheme|null $ticketingPriceScheme
+     * @param array $formOfPayment
      */
     public function __construct(
         array $flightOptions,
@@ -82,7 +85,8 @@ class FareOptions
         $feeIds,
         $corporateQualifier,
         $multiTicket,
-        $ticketingPriceScheme
+        $ticketingPriceScheme,
+        array $formOfPayment
     ) {
         if ($tickPreCheck === true) {
             $this->addPriceType(PricingTicketing::PRICETYPE_TICKETABILITY_PRECHECK);
@@ -104,6 +108,9 @@ class FareOptions
         }
         if (!is_null($ticketingPriceScheme)) {
             $this->loadTicketingPriceScheme($ticketingPriceScheme);
+        }
+        if (!is_null($formOfPayment) && count($formOfPayment)) {
+            $this->loadFormOfPayment($formOfPayment);
         }
     }
 
@@ -173,5 +180,17 @@ class FareOptions
         $priceScheme->status = $ticketingPriceScheme->status;
         $priceScheme->description = $ticketingPriceScheme->description;
         $this->ticketingPriceScheme = $priceScheme;
+    }
+
+    protected function loadFormOfPayment(array $formOfPayment)
+    {
+        /** @var \Amadeus\Client\RequestOptions\Fare\MasterPricer\FormOfPaymentDetails $fop */
+        foreach ($formOfPayment as $fop) {
+            $this->formOfPayment[] = new FormOfPaymentDetails(
+                $fop->type,
+                $fop->creditCardNumber,
+                $fop->chargedAmount
+            );
+        }
     }
 }

--- a/src/Amadeus/Client/Struct/Fare/MasterPricer/FareOptions.php
+++ b/src/Amadeus/Client/Struct/Fare/MasterPricer/FareOptions.php
@@ -75,7 +75,7 @@ class FareOptions
      * @param string|null Corporate qualifier for Corporate Unifares
      * @param $multiTicket
      * @param MPTicketingPriceScheme|null $ticketingPriceScheme
-     * @param array $formOfPayment
+     * @param array|null $formOfPayment
      */
     public function __construct(
         array $flightOptions,
@@ -86,7 +86,7 @@ class FareOptions
         $corporateQualifier,
         $multiTicket,
         $ticketingPriceScheme,
-        array $formOfPayment
+        $formOfPayment
     ) {
         if ($tickPreCheck === true) {
             $this->addPriceType(PricingTicketing::PRICETYPE_TICKETABILITY_PRECHECK);
@@ -188,8 +188,8 @@ class FareOptions
         foreach ($formOfPayment as $fop) {
             $this->formOfPayment[] = new FormOfPaymentDetails(
                 $fop->type,
-                $fop->creditCardNumber,
-                $fop->chargedAmount
+                $fop->chargedAmount,
+                $fop->creditCardNumber
             );
         }
     }

--- a/src/Amadeus/Client/Struct/Fare/MasterPricer/FormOfPaymentDetails.php
+++ b/src/Amadeus/Client/Struct/Fare/MasterPricer/FormOfPaymentDetails.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * amadeus-ws-client
+ *
+ * Copyright 2015 Amadeus Benelux NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @package Amadeus
+ * @license https://opensource.org/licenses/Apache-2.0 Apache 2.0
+ */
+
+namespace Amadeus\Client\Struct\Fare\MasterPricer;
+
+/**
+ * FormOfPaymentDetails
+ *
+ * @package Amadeus\Client\Struct\Fare\MasterPricer
+ * @author Artem Zakharchenko <artz.relax@gmail.com>
+ */
+class FormOfPaymentDetails
+{
+    /**
+     * @var string
+     */
+    public $type;
+
+    /**
+     * @var string
+     */
+    public $creditCardNumber;
+
+    /**
+     * @var string|int|float|null
+     */
+    public $chargedAmount;
+
+    public function __construct($type, $creditCardNumber, $chargedAmount = null)
+    {
+        $this->type = $type;
+        $this->creditCardNumber = $creditCardNumber;
+        $this->chargedAmount = $chargedAmount;
+    }
+}

--- a/src/Amadeus/Client/Struct/Fare/MasterPricer/FormOfPaymentDetails.php
+++ b/src/Amadeus/Client/Struct/Fare/MasterPricer/FormOfPaymentDetails.php
@@ -36,19 +36,19 @@ class FormOfPaymentDetails
     public $type;
 
     /**
-     * @var string
-     */
-    public $creditCardNumber;
-
-    /**
      * @var string|int|float|null
      */
     public $chargedAmount;
 
-    public function __construct($type, $creditCardNumber, $chargedAmount = null)
+    /**
+     * @var string|null
+     */
+    public $creditCardNumber;
+
+    public function __construct($type, $chargedAmount = null, $creditCardNumber = null)
     {
         $this->type = $type;
-        $this->creditCardNumber = $creditCardNumber;
         $this->chargedAmount = $chargedAmount;
+        $this->creditCardNumber = $creditCardNumber;
     }
 }

--- a/tests/Amadeus/Client/Struct/Fare/MasterPricer/FormOfPaymentDetailsTest.php
+++ b/tests/Amadeus/Client/Struct/Fare/MasterPricer/FormOfPaymentDetailsTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * amadeus-ws-client
+ *
+ * Copyright 2015 Amadeus Benelux NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @package Amadeus
+ * @license https://opensource.org/licenses/Apache-2.0 Apache 2.0
+ */
+
+namespace Test\Amadeus\Client\Struct\Fare\MasterPricer;
+
+use Amadeus\Client\Struct\Fare\MasterPricer\FormOfPaymentDetails;
+use Test\Amadeus\BaseTestCase;
+
+/**
+ * FormOfPaymentDetailsTest
+ *
+ * @package Test\Amadeus\Client\Struct\Fare\MasterPricer
+ * @author Artem Zakharchenko <artz.relax@gmail.com>
+ */
+class FormOfPaymentDetailsTest extends BaseTestCase
+{
+    public function testCanMakeFormOfPaymentDetailsWithAllOptions()
+    {
+        $formOfPaymentDetails = new FormOfPaymentDetails('CC', 100, '123456');
+
+        $this->assertEquals('CC', $formOfPaymentDetails->type);
+        $this->assertEquals(100, $formOfPaymentDetails->chargedAmount);
+        $this->assertEquals('123456', $formOfPaymentDetails->creditCardNumber);
+    }
+
+    public function testCanMakeFormOfPaymentDetailsWithoutOptionals()
+    {
+        $formOfPaymentDetails = new FormOfPaymentDetails('CA');
+
+        $this->assertEquals('CA', $formOfPaymentDetails->type);
+        $this->assertNull($formOfPaymentDetails->chargedAmount);
+        $this->assertNull($formOfPaymentDetails->creditCardNumber);
+    }
+}

--- a/tests/Amadeus/Client/Struct/Fare/MasterPricerTravelBoardSearchTest.php
+++ b/tests/Amadeus/Client/Struct/Fare/MasterPricerTravelBoardSearchTest.php
@@ -25,6 +25,7 @@ namespace Test\Amadeus\Client\Struct\Fare;
 use Amadeus\Client\RequestOptions\Fare\MasterPricer\FeeDetails;
 use Amadeus\Client\RequestOptions\Fare\MasterPricer\FFCriteria;
 use Amadeus\Client\RequestOptions\Fare\MasterPricer\FFOtherCriteria;
+use Amadeus\Client\RequestOptions\Fare\MasterPricer\FormOfPaymentDetails;
 use Amadeus\Client\RequestOptions\Fare\MasterPricer\MonetaryDetails;
 use Amadeus\Client\RequestOptions\Fare\MasterPricer\MultiTicketWeights;
 use Amadeus\Client\RequestOptions\Fare\MPDate;
@@ -1805,4 +1806,32 @@ class MasterPricerTravelBoardSearchTest extends BaseTestCase
         $this->assertNull($message->itinerary[0]->flightInfo->cabinId->cabinQualifier);
     }
 
+    public function testCanSpecifyFormOfPayment()
+    {
+        $opt = new FareMasterPricerTbSearch();
+        $opt->nrOfRequestedResults = 200;
+        $opt->nrOfRequestedPassengers = 1;
+        $opt->passengers[] = new MPPassenger([
+            'type' => MPPassenger::TYPE_ADULT,
+            'count' => 1
+        ]);
+        $opt->itinerary[] = new MPItinerary([
+            'departureLocation' => new MPLocation(['city' => 'BRU']),
+            'arrivalLocation' => new MPLocation(['city' => 'LON']),
+            'date' => new MPDate(['dateTime' => new \DateTime('2017-01-15T00:00:00+0000', new \DateTimeZone('UTC'))])
+        ]);
+        $opt->formOfPayment = [
+            new FormOfPaymentDetails([
+                'type' => FormOfPaymentDetails::TYPE_CREDIT_CARD,
+                'chargedAmount' => 100,
+                'creditCardNumber' => '123456'
+            ])
+        ];
+
+        $message = new MasterPricerTravelBoardSearch($opt);
+
+        $this->assertEquals('CC', $message->fareOptions->formOfPayment[0]->type);
+        $this->assertEquals(100, $message->fareOptions->formOfPayment[0]->chargedAmount);
+        $this->assertEquals('123456', $message->fareOptions->formOfPayment[0]->creditCardNumber);
+    }
 }


### PR DESCRIPTION
Implementation of `formOfPayment` option for _MasterPricer_ messages.
Request message generates correctly, Amadeus returns search results. Tested in PDT.

Resolves #273 