### PR TITLE
update example to work with tour code

### DIFF
--- a/docs/samples/pnr-create-modify.rst
+++ b/docs/samples/pnr-create-modify.rst
@@ -507,7 +507,7 @@ Create an ``FT`` element (Tour Code):
     $opt = new PnrAddMultiElementsOptions([
         'elements' => [
             new TourCode([
-                'passengerType' => TourCode::PAXTYPE_PASSENGER,
+                'passengerType' => TourCode::PAX_PASSENGER,
                 'freeText' => 'TOUR CODE'
             ])
         ]


### PR DESCRIPTION
there is no attribute `PAXTYPE_PASSENGER` in TourCode class.