### PR TITLE
Extractor refactoring

### DIFF
--- a/src/Amadeus/Client/Session/Handler/Base.php
+++ b/src/Amadeus/Client/Session/Handler/Base.php
@@ -126,6 +126,11 @@ abstract class Base implements HandlerInterface, LoggerAwareInterface
     protected $messagesAndVersions = [];
 
     /**
+     * @var Client\Util\MsgBodyExtractor
+     */
+    protected $extractor;
+
+    /**
      * Get the session parameters of the active session
      *
      * @return array|null
@@ -172,6 +177,7 @@ abstract class Base implements HandlerInterface, LoggerAwareInterface
         $this->setStateful($params->stateful);
         $this->setTransactionFlowLink($params->enableTransactionFlowLink);
         $this->setConsumerId($params->consumerId);
+        $this->extractor = new Client\Util\MsgBodyExtractor();
     }
 
 
@@ -219,7 +225,7 @@ abstract class Base implements HandlerInterface, LoggerAwareInterface
             throw new Client\Exception($ex->getMessage(), $ex->getCode(), $ex);
         }
 
-        $result->responseXml = Client\Util\MsgBodyExtractor::extract($this->getLastResponse($messageName));
+        $result->responseXml = $this->extractor->extract($this->getLastResponse($messageName));
 
         return $result;
     }

--- a/src/Amadeus/Client/Util/MsgBodyExtractor.php
+++ b/src/Amadeus/Client/Util/MsgBodyExtractor.php
@@ -40,10 +40,10 @@ class MsgBodyExtractor
     {
         $messageBody = null;
 
-        $messageBody = self::getStringBetween($soapResponse, '<SOAP-ENV:Body>', '</SOAP-ENV:Body>');
+        $messageBody = $this->getStringBetween($soapResponse, '<SOAP-ENV:Body>', '</SOAP-ENV:Body>');
 
         if (empty($messageBody) || false === $messageBody) {
-            $messageBody = self::getStringBetween($soapResponse, '<soap:Body>', '</soap:Body>');
+            $messageBody = $this->getStringBetween($soapResponse, '<soap:Body>', '</soap:Body>');
         }
 
         return $messageBody;

--- a/src/Amadeus/Client/Util/MsgBodyExtractor.php
+++ b/src/Amadeus/Client/Util/MsgBodyExtractor.php
@@ -31,40 +31,38 @@ namespace Amadeus\Client\Util;
 class MsgBodyExtractor
 {
     /**
-     * Regular expression for extracting the Soap Envelope Body's content.
-     *
-     * @var string
-     */
-    const REGEXP_SOAP_ENVELOPE_CONTENTS = "|\\<SOAP-ENV:Body\\>(.*?)\\<\\/SOAP-ENV:Body\\>|s";
-
-    /**
-     * Regular expression for extracting the Soap Envelope Body's content - legacy format for Soap Header v2 and older
-     *
-     * @var string
-     */
-    const REGEXP_SOAP_ENVELOPE_CONTENTS_LEGACY = "|\\<soap:Body\\>(.*?)\\<\\/soap:Body\\>|s";
-
-    /**
      * Extracts the message content from the soap envelope (i.e. everything under the soap body)
      *
      * @param string $soapResponse
      * @return string|null
      */
-    public static function extract($soapResponse)
+    public function extract($soapResponse)
     {
         $messageBody = null;
-        $matches = [];
 
-        if (preg_match(self::REGEXP_SOAP_ENVELOPE_CONTENTS, $soapResponse, $matches) === 1) {
-            $messageBody = $matches[1];
-        }
+        $messageBody = self::getStringBetween($soapResponse, '<SOAP-ENV:Body>', '</SOAP-ENV:Body>');
 
-        if (empty($messageBody)) {
-            if (preg_match(self::REGEXP_SOAP_ENVELOPE_CONTENTS_LEGACY, $soapResponse, $matches) === 1) {
-                $messageBody = $matches[1];
-            }
+        if (empty($messageBody) || false === $messageBody) {
+            $messageBody = self::getStringBetween($soapResponse, '<soap:Body>', '</soap:Body>');
         }
 
         return $messageBody;
+    }
+
+    /**
+     * Get substring between two strings
+     *
+     * @param $string
+     * @param $start
+     * @param $end
+     * @return bool|string
+     */
+    private function getStringBetween($string, $start, $end)
+    {
+        $startPos = strpos($string, $start) + strlen($start);
+
+        $endPos = strlen($string) - strpos($string, $end);
+
+        return substr($string, $startPos, -$endPos);
     }
 }

--- a/tests/Amadeus/Client/Session/Handler/SoapHeader2Test.php
+++ b/tests/Amadeus/Client/Session/Handler/SoapHeader2Test.php
@@ -122,13 +122,14 @@ class SoapHeader2Test extends BaseTestCase
         $dummyRequest = $this->getTestFile('soapheader2' . DIRECTORY_SEPARATOR . 'dummySecurityAuth.txt');
         $dummyReply = $this->getTestFile('soapheader2' . DIRECTORY_SEPARATOR . 'dummySecurityAuthReply.txt');
 
+        $extractor = new Client\Util\MsgBodyExtractor();
         $wsResponse = new \stdClass();
         $wsResponse->processStatus = new \stdClass();
         $wsResponse->processStatus->statusCode = 'P';
 
         $messageResult = new SendResult();
         $messageResult->responseObject = $wsResponse;
-        $messageResult->responseXml = Client\Util\MsgBodyExtractor::extract($dummyReply);
+        $messageResult->responseXml = $extractor->extract($dummyReply);
         $messageResult->messageVersion = '6.1';
 
 

--- a/tests/Amadeus/Client/Session/Handler/SoapHeader4Test.php
+++ b/tests/Amadeus/Client/Session/Handler/SoapHeader4Test.php
@@ -761,7 +761,8 @@ xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-u
         $this->assertInstanceOf('\SoapFault', $sendResult->exception);
         $this->assertEquals('284|Application|SECURED PNR', $sendResult->exception->getMessage());
         $this->assertEquals('11.3', $sendResult->messageVersion);
-        $this->assertEquals(Client\Util\MsgBodyExtractor::extract($dummyPnrReply), $sendResult->responseXml);
+        $extractor = new Client\Util\MsgBodyExtractor();
+        $this->assertEquals($extractor->extract($dummyPnrReply), $sendResult->responseXml);
     }
 
     public function testCanHandleMessageThrowingNonSoapFaultException()

--- a/tests/Amadeus/Client/Util/MsgBodyExtractorTest.php
+++ b/tests/Amadeus/Client/Util/MsgBodyExtractorTest.php
@@ -39,7 +39,8 @@ class MsgBodyExtractorTest extends BaseTestCase
         $xml = $this->getTestFile("pnrResponseFullEnvelope.txt");
         $expectedResult = $this->getTestFile("pnrResponseFullEnvelopeOnlyPnrReply.txt");
 
-        $actual = MsgBodyExtractor::extract($xml);
+        $extractor = new MsgBodyExtractor();
+        $actual = $extractor->extract($xml);
 
         $this->assertEquals($expectedResult, $actual);
     }
@@ -49,7 +50,8 @@ class MsgBodyExtractorTest extends BaseTestCase
         $xml = $this->getTestFile("dummyPnrRetrieveWithNewLine.txt");
         $expectedResult = $this->getTestFile("dummyPnrRetrieveWithNewLineOnlyPnrReply.txt");
 
-        $actual = MsgBodyExtractor::extract($xml);
+        $extractor = new MsgBodyExtractor();
+        $actual = $extractor->extract($xml);
 
         $this->assertEquals($expectedResult, $actual);
     }


### PR DESCRIPTION
Resolves #302 

Also using substrings handles whole XML string faster than with `preg_match`. For few milliseconds less, but anyway :)