### PR TITLE
fix for #429: no session after PNR Retrieve failed

### DIFF
--- a/src/Amadeus/Client/Session/Handler/Base.php
+++ b/src/Amadeus/Client/Session/Handler/Base.php
@@ -212,6 +212,7 @@ abstract class Base implements HandlerInterface, LoggerAwareInterface
                 ": \n".$ex->getTraceAsString()
             );
             $this->logRequestAndResponse($messageName);
+            $this->handlePostMessage($messageName, $this->getLastResponse($messageName), $messageOptions, $result);
             $result->exception = $ex;
         } catch (\Exception $ex) {
             // We should only come here when the XSL extension is not enabled


### PR DESCRIPTION
This should fix #429 . When catching the SoapFault, the post-message session check did not occur.