### PR TITLE
Add support for multiple pax types in MasterPricerTravelBoard

### DIFF
--- a/docs/samples/masterpricertravelboard.rst
+++ b/docs/samples/masterpricertravelboard.rst
@@ -911,9 +911,9 @@ Multi-Ticket
 ============
 
 The Multi-Ticket option allows you to get inbound, outbound and complete flights in one response.
-Works only on return trip search. 
+Works only on return trip search.
 
-`multiTicketWeights` is optional. If passed the sum of each weight has to sum up to 100. 
+`multiTicketWeights` is optional. If passed the sum of each weight has to sum up to 100.
 
 .. code-block:: php
 
@@ -1355,3 +1355,41 @@ See all available type codes in `Amadeus\Client\RequestOptions\Fare\MasterPricer
         ]
     ]);
 
+Multiple passenger types
+========================
+
+In case you need to combine passenger types to get some specific private fares in union with ADT private fares.
+It will returned both ADT and IIT fares for one passenger.
+
+.. code-block:: php
+
+    use Amadeus\Client\RequestOptions\FareMasterPricerTbSearch;
+    use Amadeus\Client\RequestOptions\Fare\MPItinerary;
+    use Amadeus\Client\RequestOptions\Fare\MPLocation;
+    use Amadeus\Client\RequestOptions\Fare\MPPassenger;
+    use Amadeus\Client\RequestOptions\Fare\MPDate;
+
+    $opt = new FareMasterPricerTbSearch([
+        'nrOfRequestedPassengers' => 1,
+        'passengers' => [
+            new MPPassenger([
+                'type' => [
+                    MPPassenger::TYPE_ADULT,
+                    MPPassenger::TYPE_INDIVIDUAL_INCLUSIVE_TOUR,
+                ],
+                'count' => 1,
+            ]),
+        ],
+        'itinerary' => [
+            new MPItinerary([
+                'departureLocation' => new MPLocation(['airport' => 'JFK']),
+                'arrivalLocation' => new MPLocation(['airport' => 'KEF']),
+                'date' => new MPDate([
+                    'dateTime' => new \DateTime('2021-11-01T00:00:00+0000', new \DateTimeZone('UTC'))
+                ]),
+            ]),
+        ],
+        'flightOptions' => [
+            FareMasterPricerTbSearch::FLIGHTOPT_UNIFARES,
+        ],
+    ]);

--- a/src/Amadeus/Client/RequestOptions/Fare/MPPassenger.php
+++ b/src/Amadeus/Client/RequestOptions/Fare/MPPassenger.php
@@ -42,10 +42,12 @@ class MPPassenger extends LoadParamsFromArray
 
     const TYPE_STUDENT = "ST";
 
+    const TYPE_INDIVIDUAL_INCLUSIVE_TOUR = 'IIT';
+
     /**
      * What type of passengers? self::TYPE_*
      *
-     * @var string
+     * @var string|array
      */
     public $type;
 

--- a/src/Amadeus/Client/Struct/Fare/MasterPricer/PaxReference.php
+++ b/src/Amadeus/Client/Struct/Fare/MasterPricer/PaxReference.php
@@ -51,6 +51,14 @@ class PaxReference
     public function __construct($mainTravellerRef, $isInfant = false, $passengerType = null)
     {
         $this->traveller[] = new Traveller($mainTravellerRef, $isInfant);
-        $this->ptc[] = $passengerType;
+        if (is_array($passengerType)) {
+            $types = $passengerType;
+        } else {
+            $types = [$passengerType];
+        }
+
+        foreach ($types as $type) {
+            $this->ptc[] = $type;
+        }
     }
 }

--- a/tests/Amadeus/Client/Struct/Fare/MasterPricerTravelBoardSearchTest.php
+++ b/tests/Amadeus/Client/Struct/Fare/MasterPricerTravelBoardSearchTest.php
@@ -1894,8 +1894,6 @@ class MasterPricerTravelBoardSearchTest extends BaseTestCase
         $this->assertEquals('20', $message->itinerary[0]->flightInfoPNR[0]->travelResponseDetails->flightIdentification->flightNumber);
         $this->assertNull($message->itinerary[0]->flightInfoPNR[0]->travelResponseDetails->flightIdentification->bookingClass);
         $this->assertEquals('AA', $message->itinerary[0]->flightInfoPNR[0]->travelResponseDetails->companyDetails->marketingCompany);
-        
-
 
         $this->assertCount(2, $message->numberOfUnit->unitNumberDetail);
         $this->assertEquals(1, $message->numberOfUnit->unitNumberDetail[0]->numberOfUnits);
@@ -1925,5 +1923,34 @@ class MasterPricerTravelBoardSearchTest extends BaseTestCase
         $this->assertNull($message->ticketChangeInfo);
         $this->assertEmpty($message->valueSearch);
         $this->assertNull($message->travelFlightInfo);
+    }
+
+    public function testUseMultiplePassengerType()
+    {
+        $opt = new FareMasterPricerTbSearch();
+        $opt->nrOfRequestedResults = 200;
+        $opt->nrOfRequestedPassengers = 1;
+        $opt->passengers[] = new MPPassenger([
+            'type' => [
+                MPPassenger::TYPE_ADULT,
+                MPPassenger::TYPE_INDIVIDUAL_INCLUSIVE_TOUR,
+            ],
+            'count' => 1
+        ]);
+        $opt->itinerary[] = new MPItinerary([
+            'departureLocation' => new MPLocation(['city' => 'JFK']),
+            'arrivalLocation' => new MPLocation(['city' => 'KEF']),
+            'date' => new MPDate(['dateTime' => new \DateTime('2017-01-15T00:00:00+0000', new \DateTimeZone('UTC'))]),
+        ]);
+
+        $message = new MasterPricerTravelBoardSearch($opt);
+        $this->assertInternalType('array', $message->paxReference);
+
+        $this->assertCount(1, $message->paxReference);
+        $this->assertCount(2, $message->paxReference[0]->ptc);
+        $this->assertEquals('ADT', $message->paxReference[0]->ptc[0]);
+        $this->assertEquals('IIT', $message->paxReference[0]->ptc[1]);
+        $this->assertCount(1, $message->paxReference[0]->traveller);
+        $this->assertEquals(1, $message->paxReference[0]->traveller[0]->ref);
     }
 }


### PR DESCRIPTION
Need an ability to define several pax types at once:

```xml
<ns1:paxReference>
    <ns1:ptc>ADT</ns1:ptc>
    <ns1:ptc>IIT</ns1:ptc>
    <ns1:traveller>
        <ns1:ref>1</ns1:ref>
    </ns1:traveller>
    <ns1:traveller>
        <ns1:ref>2</ns1:ref>
    </ns1:traveller>
</ns1:paxReference>
```

Tested with PRD env.