### PR TITLE
add 3DS v2.0 params with external authentication in FOP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+* Added Support for 3DS v2.0 with external Authentication in FOP_CreateFormOfPayment
 
 ## Release 1.13.0 (5 Apr 2021)
 * Add support for multiple pax types in Fare_MasterPricerTravelBoardSearch (https://github.com/amabnl/amadeus-ws-client/pull/432)  - Artem Zakharchenko

--- a/docs/samples/fop-createfop.rst
+++ b/docs/samples/fop-createfop.rst
@@ -60,6 +60,68 @@ Query and response for handling 3DS data.
     $fopResponse = $client->fopCreateFormOfPayment($options);
 
 
+3D-Secure payment version 2.x with external authentication
+=================
+
+.. code-block:: php
+
+    use Amadeus\Client\RequestOptions\Fop\CreditCardInfo;
+    use Amadeus\Client\RequestOptions\Fop\CreditCardSupplementaryData;
+    use Amadeus\Client\RequestOptions\Fop\Group;
+    use Amadeus\Client\RequestOptions\Fop\MopInfo;
+    use Amadeus\Client\RequestOptions\Fop\ThreeDSecureInfo;
+    use Amadeus\Client\RequestOptions\FopCreateFopOptions;
+    use Amadeus\Client\Struct\Fop\AttributeDetails;
+
+    $options = new FopCreateFopOptions([
+        'transactionCode' => FopCreateFopOptions::TRANS_CREATE_FORM_OF_PAYMENT,
+        'fopGroup' => [
+            new Group([
+                'mopInfo' => [
+                    new MopInfo([
+                        'fopType' => 'CC',
+                        'attributeType' => AttributeDetails::TYPE_FP_ELEMENT,
+                        'payMerchant' => 'EW',
+                        'mopPaymentType' => MopInfo::MOP_PAY_TYPE_CREDIT_CARD,
+                        'creditCardInfo' => new CreditCardInfo([
+                            'name' => 'Name Surname',
+                            'cardNumber' => 'XXXXXXXXXXXX0003',
+                            'vendorCode' => 'VI',
+                            'expiryDate' => '1020',
+                            'securityId' => '999',
+                            'threeDSecure' => new ThreeDSecureInfo([
+                                'transactionsStatus' => ThreeDSecureInfo::PARES_AUTHENTICATION_SUCCESSFUL,
+                                'tdsVersion' => '2.0.1',
+                                'creditCardCompany' => ThreeDSecureInfo::CC_COMP_VISA_DIRECTORY_SERVER,
+                                'authenticationIndicator' => '05',
+                                'tdsServerTransactionId' => 'U0RTRzNTRUczNEdTR1NFUldXRkNXRkRXRUZFRw==',
+                                'tdsServerTransactionIdLength' => 28,
+                                'directoryServerTransactionId' => 'Q2pENDJ0Tll0WlZ6VFcwSEVvdDVIRGt4TXpFPQ',
+                                'directoryServerTransactionIdLength' => 28,
+                                'tdsAuthenticationVerificationCode' => 'QUFBQkJYbGprUUFBQUFBRUFXT1JBQUFBQUFBPQ',
+                                'tdsAuthenticationVerificationCodeLength' => 28,
+                                'tdsAuthenticationVerificationCodeReference' => ThreeDSecureInfo::AUTHENTICATION_VERIFICATION_CODE_VISA
+                            ]),
+                            'supplementaryData' => [
+                                new CreditCardSupplementaryData([
+                                    'setType' => CreditCardSupplementaryData::SET_TYPE_3DS,
+                                    'attributeType' => CreditCardSupplementaryData::ATTRIBUTE_TYPE_EXTERNAL_AUTHENTICATION,
+                                    'attributeDescription' => CreditCardSupplementaryData::ATTRIBUTE_DESCRIPTION_Y,
+                                ])
+                            ]
+                        ]),
+                        'sequenceNr' => 1,
+                        'fopCode' => CC,
+                        'fopStatus' => MopInfo::STATUS_NEW,
+                    ])
+                ]
+            ])
+        ]
+    ]);
+
+    $fopResponse = $client->fopCreateFormOfPayment($options);
+
+
 Best Effort
 ===========
 

--- a/src/Amadeus/Client/RequestOptions/Fop/CreditCardInfo.php
+++ b/src/Amadeus/Client/RequestOptions/Fop/CreditCardInfo.php
@@ -107,4 +107,9 @@ class CreditCardInfo extends LoadParamsFromArray
      * @var ThreeDSecureInfo
      */
     public $threeDSecure;
+
+    /**
+     * @var CreditCardSupplementaryData[]
+     */
+    public $supplementaryData = [];
 }

--- a/src/Amadeus/Client/RequestOptions/Fop/CreditCardSupplementaryData.php
+++ b/src/Amadeus/Client/RequestOptions/Fop/CreditCardSupplementaryData.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * amadeus-ws-client
+ *
+ * Copyright 2015 Amadeus Benelux NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @package Amadeus
+ * @license https://opensource.org/licenses/Apache-2.0 Apache 2.0
+ */
+
+namespace Amadeus\Client\RequestOptions\Fop;
+
+use Amadeus\Client\LoadParamsFromArray;
+
+/**
+ * CreditCardInfo
+ *
+ * @package Amadeus\Client\RequestOptions\Fop
+ * @author Friedemann Schmuhl <friedemann.schmuhl@invia.de>
+ */
+class CreditCardSupplementaryData extends LoadParamsFromArray
+{
+    const SET_TYPE_AUTHENTICATION = 'ATN';
+    const SET_TYPE_AUTHORIZATION  = 'AUT';
+    const SET_TYPE_3DS            = '3DS';
+
+    const ATTRIBUTE_TYPE_EXTERNAL_AUTHENTICATION = 'EXTERNAL_AUTHENTICATION';
+
+    const ATTRIBUTE_DESCRIPTION_Y = 'Y';
+
+    /**
+     * Type of Data related to FOP account
+     *
+     * @var string
+     */
+    public $setType;
+
+    /**
+     * Used to add data related to FOP Account
+     *
+     * @var string
+     */
+    public $attributeType;
+
+    /**
+     * This is the data value.  This may contain:  - a potential attribute of the switch  - the value of the structured data of the FOP
+     *
+     * @var string
+     */
+    public $attributeDescription;
+}

--- a/src/Amadeus/Client/RequestOptions/Fop/MopInfo.php
+++ b/src/Amadeus/Client/RequestOptions/Fop/MopInfo.php
@@ -122,6 +122,15 @@ class MopInfo extends LoadParamsFromArray
     public $fopType;
 
     /**
+     * Describe one processing option at FOP level
+     *
+     * AttributeDetails::TYPE_*
+     *
+     * @var string
+     */
+    public $attributeType;
+
+    /**
      * The Merchant company
      *
      * @var string

--- a/src/Amadeus/Client/RequestOptions/Fop/ThreeDSecureInfo.php
+++ b/src/Amadeus/Client/RequestOptions/Fop/ThreeDSecureInfo.php
@@ -42,11 +42,26 @@ class ThreeDSecureInfo extends LoadParamsFromArray
     const PARES_AUTHENTICATION_UNABLE = "U";
     const PARES_AUTHENTICATION_SUCCESSFUL = "Y";
 
+    const TRANSACTION_STATUS_ATTEMPTED_AUTHENTICATION = "A";
+    const TRANSACTION_STATUS_AUTHENTICATION_FAILED = "N";
+    const TRANSACTION_STATUS_AUTHENTICATION_UNABLE = "U";
+    const TRANSACTION_STATUS_AUTHENTICATION_SUCCESSFUL = "Y";
+
     const CC_COMP_MASTERCARD_DIRECTORY_SERVER = "CADS";
     const CC_COMP_VISA_DIRECTORY_SERVER = "VIDS";
 
     const DATATYPE_BINARY = "B";
     const DATATYPE_EDIFACT = "E";
+
+    const CREDIT_CARD_COMPANY_VISA = 'VIDS';
+    const CREDIT_CARD_COMPANY_MASTER_CARD = 'CADS';
+    const CREDIT_CARD_COMPANY_AMERICAN_EXPRESS = 'AXDS';
+    const CREDIT_CARD_COMPANY_DINERS = 'DCDS';
+    const CREDIT_CARD_COMPANY_JCB = 'JCDS';
+
+    const AUTHENTICATION_VERIFICATION_CODE_VISA = 'CAVV';
+    const AUTHENTICATION_VERIFICATION_CODE_AMERICAN_EXPRESS  = 'AEVV';
+    const AUTHENTICATION_VERIFICATION_CODE_MASTERCARD  = 'AAV';
 
     /**
      * VERES status
@@ -67,11 +82,26 @@ class ThreeDSecureInfo extends LoadParamsFromArray
     public $paresStatus;
 
     /**
+     * Transaction status
+     *
+     * self::TRANSACTION_STATUS_*
+     *
+     * @var string
+     */
+    public $transactionsStatus;
+    /**
      * self::CC_COMP_*
      *
      * @var string
      */
     public $creditCardCompany;
+
+    /**
+     * Indicates the status of the enrolment and authentication phases
+     *
+     * @var string
+     */
+    public $authenticationIndicator;
 
     /**
      * Access Control Server URL
@@ -100,6 +130,79 @@ class ThreeDSecureInfo extends LoadParamsFromArray
      * @var int
      */
     public $transactionIdentifierLength;
+
+    /**
+     * 3DS protocol version
+     *
+     * @var string
+     */
+    public $tdsVersion;
+
+    /**
+     * 3DS 2.0 partner transaction identifier
+     *
+     * @var string
+     */
+    public $tdsServerTransactionId;
+
+    /**
+     * @var string
+     */
+    public $tdsServerTransactionIdDataType = self::DATATYPE_BINARY;
+
+    /**
+     * Length of 3DS 2.0 partner transaction identifier
+     *
+     * @var string
+     */
+    public $tdsServerTransactionIdLength;
+
+    /**
+     * 3DS authentication verification code
+     *
+     * @var string
+     */
+    public $tdsAuthenticationVerificationCode;
+
+    /**
+     * 3DS authentication verification code reference (CAVV : Visa, Diners, JCB AEVV : American Express AAV : Mastercard)
+     *
+     * @var string
+     */
+    public $tdsAuthenticationVerificationCodeReference;
+
+    /**
+     * @var string
+     */
+    public $tdsAuthenticationVerificationCodeDataType =  self::DATATYPE_BINARY;
+
+    /**
+     * 3DS authentication verification code
+     *
+     * @var int
+     */
+    public $tdsAuthenticationVerificationCodeLength;
+
+    /**
+     * Transaction identifier related to the Directory Server
+     *
+     * @package Amadeus\Client\RequestOptions\Fop
+     *
+     * @var string
+     */
+    public $directoryServerTransactionId;
+
+    /**
+     * @var string
+     */
+    public $directoryServerTransactionIdDataType = self::DATATYPE_BINARY;
+
+    /**
+     * Length of Directory Server Transaction Identifier string
+     *
+     * @var int
+     */
+    public $directoryServerTransactionIdLength;
 
     /**
      * PARES Authentication response

--- a/src/Amadeus/Client/Struct/Fop/AuthenticationData.php
+++ b/src/Amadeus/Client/Struct/Fop/AuthenticationData.php
@@ -36,18 +36,30 @@ class AuthenticationData
     public $authenticationDataDetails;
 
     /**
+     * Version of the 3DS protocol
+     * @var string
+     */
+    public $tdsVersion;
+
+    /**
      * AuthenticationData constructor.
      *
      * @param string|null $veresStatus
      * @param string|null $paresStatus
      * @param string|null $company
      */
-    public function __construct($veresStatus, $paresStatus, $company)
+    public function __construct($veresStatus, $paresStatus, $company, $transactionsStatus, $authenticationIndicator, $tdsVersion)
     {
+        if (false === empty($tdsVersion)) {
+            $this->tdsVersion = $tdsVersion;
+        }
+
         $this->authenticationDataDetails = new AuthenticationDataDetails(
             $veresStatus,
             $paresStatus,
-            $company
+            $company,
+            $transactionsStatus,
+            $authenticationIndicator
         );
     }
 }

--- a/src/Amadeus/Client/Struct/Fop/AuthenticationDataDetails.php
+++ b/src/Amadeus/Client/Struct/Fop/AuthenticationDataDetails.php
@@ -26,7 +26,7 @@ namespace Amadeus\Client\Struct\Fop;
  * AuthenticationDataDetails
  *
  * @package Amadeus\Client\Struct\Fop
- * @author Dieter Devlieghere <dermikagh@gmail.com>
+ * @author  Dieter Devlieghere <dermikagh@gmail.com>
  */
 class AuthenticationDataDetails
 {
@@ -50,6 +50,16 @@ class AuthenticationDataDetails
      * @var string
      */
     public $pares;
+
+    /**
+     * A : attempt processing performed
+     * N : authentication failed
+     * U : unable to authenticate
+     * Y : authentication successful
+     *
+     * @var string
+     */
+    public $transStatus;
 
     /**
      * CADS MasterCard Directory Server
@@ -92,10 +102,12 @@ class AuthenticationDataDetails
      * @param string|null $paresStatus
      * @param string|null $company
      */
-    public function __construct($veresStatus, $paresStatus, $company)
+    public function __construct($veresStatus, $paresStatus, $company, $transactionsStatus, $authenticationIndicator)
     {
-        $this->veres = $veresStatus;
-        $this->pares = $paresStatus;
-        $this->creditCardCompany = $company;
+        $this->veres                   = $veresStatus;
+        $this->pares                   = $paresStatus;
+        $this->creditCardCompany       = $company;
+        $this->transStatus             = $transactionsStatus;
+        $this->authenticationIndicator = $authenticationIndicator;
     }
 }

--- a/src/Amadeus/Client/Struct/Fop/CardSupplementaryCriteriaDetails.php
+++ b/src/Amadeus/Client/Struct/Fop/CardSupplementaryCriteriaDetails.php
@@ -23,32 +23,30 @@
 namespace Amadeus\Client\Struct\Fop;
 
 /**
- * TdsReferenceDetails
+ * CardSupplementaryCriteriaDetails
  *
  * @package Amadeus\Client\Struct\Fop
- * @author Dieter Devlieghere <dermikagh@gmail.com>
+ * @author Friedemann Schmuhl <friedemann.schmuhl@invia.de>
  */
-class TdsReferenceDetails
+class CardSupplementaryCriteriaDetails
 {
-    const REF_PARES = 'PARES';
-    const REF_VISA_CARD = 'CAVV';
-    const REF_MASTERCARD = 'AVVV';
-    const REF_THREEDS_TRANSACTION_IDENTIFIER = 'XID';
-    const REG_THREEDS_SERVER_TRANSACTION_ID = '3DS_SERVER_TRANSACTIONID';
-    const REG_DIRECTORY_SERVER_TRANSACTION_ID = 'DS_TRANSACTIONID';
+    /**
+     * @var string
+     */
+    public $attributeType;
 
     /**
      * @var string
      */
-    public $value;
+    public $attributeDescription;
 
     /**
-     * TdsReferenceDetails constructor.
-     *
-     * @param string $value self::REF_*
+     * @param string $attributeType
+     * @param string $attributeDescription
      */
-    public function __construct($value)
+    public function __construct($attributeType, $attributeDescription)
     {
-        $this->value = $value;
+        $this->attributeType        = $attributeType;
+        $this->attributeDescription = $attributeDescription;
     }
 }

--- a/src/Amadeus/Client/Struct/Fop/CardSupplementaryData.php
+++ b/src/Amadeus/Client/Struct/Fop/CardSupplementaryData.php
@@ -30,4 +30,16 @@ namespace Amadeus\Client\Struct\Fop;
  */
 class CardSupplementaryData
 {
+    public $criteriaSetType;
+
+    /**
+     * @var CardSupplementaryCriteriaDetails
+     */
+    public $criteriaDetails;
+
+    public function __construct($setType, $attributeType, $attributeDescription)
+    {
+        $this->criteriaSetType = $setType;
+        $this->criteriaDetails = new CardSupplementaryCriteriaDetails($attributeType, $attributeDescription);
+    }
 }

--- a/src/Amadeus/Client/Struct/Fop/CreateFormOfPayment/GroupUsage14.php
+++ b/src/Amadeus/Client/Struct/Fop/CreateFormOfPayment/GroupUsage14.php
@@ -41,10 +41,10 @@ class GroupUsage14 extends GroupUsage
     /**
      * GroupUsage constructor.
      *
-     * @param string $fopType AttributeDetails::TYPE_*
+     * @param string $attributeType AttributeDetails::TYPE_*
      */
-    public function __construct($fopType)
+    public function __construct($attributeType)
     {
-        $this->attributeDetails = new AttributeDetails($fopType);
+        $this->attributeDetails = new AttributeDetails($attributeType);
     }
 }

--- a/src/Amadeus/Client/Struct/Fop/CreditCardDetailedData.php
+++ b/src/Amadeus/Client/Struct/Fop/CreditCardDetailedData.php
@@ -22,6 +22,7 @@
 
 namespace Amadeus\Client\Struct\Fop;
 
+use Amadeus\Client\RequestOptions\Fop\CreditCardSupplementaryData;
 use Amadeus\Client\RequestOptions\Fop\ThreeDSecureInfo;
 use Amadeus\Client\Struct\WsMessageUtility;
 
@@ -79,8 +80,9 @@ class CreditCardDetailedData extends WsMessageUtility
      * @param string $approvalCode
      * @param string $approvalSource
      * @param ThreeDSecureInfo|null $threeDSecure
+     * @param CreditCardSupplementaryData[] $cardSupplementaryData
      */
-    public function __construct($approvalCode, $approvalSource, $threeDSecure = null)
+    public function __construct($approvalCode, $approvalSource, $threeDSecure = null, $cardSupplementaryData = null)
     {
         if (!empty($approvalCode)) {
             $this->approvalDetails = new ApprovalDetails($approvalCode, $approvalSource);
@@ -88,6 +90,16 @@ class CreditCardDetailedData extends WsMessageUtility
 
         if ($threeDSecure instanceof ThreeDSecureInfo) {
             $this->tdsInformation = new TdsInformation($threeDSecure);
+        }
+
+        if (is_array($cardSupplementaryData)) {
+            foreach ($cardSupplementaryData as $cardSupplementaryDatum) {
+                $this->cardSupplementaryData[] = new CardSupplementaryData(
+                    $cardSupplementaryDatum->setType,
+                    $cardSupplementaryDatum->attributeType,
+                    $cardSupplementaryDatum->attributeDescription
+                );
+            }
         }
     }
 }

--- a/src/Amadeus/Client/Struct/Fop/GroupUsage.php
+++ b/src/Amadeus/Client/Struct/Fop/GroupUsage.php
@@ -38,10 +38,10 @@ class GroupUsage
     /**
      * GroupUsage constructor.
      *
-     * @param string $fopType AttributeDetails::TYPE_*
+     * @param string $attributeType AttributeDetails::TYPE_*
      */
-    public function __construct($fopType)
+    public function __construct($attributeType)
     {
-        $this->attributeDetails[] = new AttributeDetails($fopType);
+        $this->attributeDetails[] = new AttributeDetails($attributeType);
     }
 }

--- a/src/Amadeus/Client/Struct/Fop/MopDescription.php
+++ b/src/Amadeus/Client/Struct/Fop/MopDescription.php
@@ -118,6 +118,7 @@ class MopDescription extends WsMessageUtility
     {
         if ($this->checkAnyNotEmpty(
             $options->fopType,
+            $options->attributeType,
             $options->payMerchant,
             $options->payments,
             $options->installmentsInfo,
@@ -127,10 +128,16 @@ class MopDescription extends WsMessageUtility
             $options->payIds,
             $options->paySupData
         )) {
+
+            /**
+             * for backwards compatibility use `$options->fopType` as default for `$attributeType`
+             */
+            $attributeType = $options->attributeType ?: $options->fopType;
+
             if ($this instanceof MopDescription14) {
-                $this->paymentModule = new PaymentModule14($options->fopType);
+                $this->paymentModule = new PaymentModule14($attributeType);
             } else {
-                $this->paymentModule = new PaymentModule($options->fopType);
+                $this->paymentModule = new PaymentModule($attributeType);
             }
             $this->paymentModule->loadPaymentData($options);
 
@@ -179,7 +186,8 @@ class MopDescription extends WsMessageUtility
                 $this->paymentModule->mopDetailedData->creditCardDetailedData = new CreditCardDetailedData(
                     $options->creditCardInfo->approvalCode,
                     $options->creditCardInfo->sourceOfApproval,
-                    $options->creditCardInfo->threeDSecure
+                    $options->creditCardInfo->threeDSecure,
+                    $options->creditCardInfo->supplementaryData
                 );
             }
         }

--- a/src/Amadeus/Client/Struct/Fop/PaymentModule.php
+++ b/src/Amadeus/Client/Struct/Fop/PaymentModule.php
@@ -73,14 +73,14 @@ class PaymentModule extends WsMessageUtility
     /**
      * PaymentModule constructor.
      *
-     * @param string $fopType
+     * @param string $attributeType
      */
-    public function __construct($fopType)
+    public function __construct($attributeType)
     {
         if ($this instanceof PaymentModule14) {
-            $this->groupUsage = new GroupUsage14($fopType);
+            $this->groupUsage = new GroupUsage14($attributeType);
         } else {
-            $this->groupUsage = new GroupUsage($fopType);
+            $this->groupUsage = new GroupUsage($attributeType);
         }
     }
 

--- a/src/Amadeus/Client/Struct/Fop/TdsInformation.php
+++ b/src/Amadeus/Client/Struct/Fop/TdsInformation.php
@@ -59,11 +59,14 @@ class TdsInformation extends WsMessageUtility
             $this->acsURL = new AcsUrl($options->acsUrl);
         }
 
-        if ($this->checkAnyNotEmpty($options->veresStatus, $options->paresStatus, $options->creditCardCompany)) {
+        if ($this->checkAnyNotEmpty($options->veresStatus, $options->paresStatus, $options->creditCardCompany, $options->transactionsStatus, $options->authenticationIndicator, $options->tdsVersion)) {
             $this->authenticationData = new AuthenticationData(
                 $options->veresStatus,
                 $options->paresStatus,
-                $options->creditCardCompany
+                $options->creditCardCompany,
+                $options->transactionsStatus,
+                $options->authenticationIndicator,
+                $options->tdsVersion
             );
         }
 
@@ -73,6 +76,33 @@ class TdsInformation extends WsMessageUtility
                 $options->transactionIdentifier,
                 $options->transactionIdentifierDataType,
                 $options->transactionIdentifierLength
+            );
+        }
+
+        if (!empty($options->tdsServerTransactionId)) {
+            $this->tdsBlobData[] = new TdsBlobData(
+                TdsReferenceDetails::REG_THREEDS_SERVER_TRANSACTION_ID,
+                $options->tdsServerTransactionId,
+                $options->tdsServerTransactionIdDataType,
+                $options->tdsServerTransactionIdLength
+            );
+        }
+
+        if (!empty($options->tdsAuthenticationVerificationCode)) {
+            $this->tdsBlobData[] = new TdsBlobData(
+                $options->tdsAuthenticationVerificationCodeReference,
+                $options->tdsAuthenticationVerificationCode,
+                $options->tdsAuthenticationVerificationCodeDataType,
+                $options->tdsAuthenticationVerificationCodeLength
+            );
+        }
+
+        if (!empty($options->directoryServerTransactionId)) {
+            $this->tdsBlobData[] = new TdsBlobData(
+                TdsReferenceDetails::REG_DIRECTORY_SERVER_TRANSACTION_ID,
+                $options->directoryServerTransactionId,
+                $options->directoryServerTransactionIdDataType,
+                $options->directoryServerTransactionIdLength
             );
         }
 

--- a/tests/Amadeus/Client/Struct/Fop/MopDescriptionTest.php
+++ b/tests/Amadeus/Client/Struct/Fop/MopDescriptionTest.php
@@ -22,8 +22,12 @@
 
 namespace Test\Amadeus\Client\Struct\Fop;
 
+use Amadeus\Client\RequestOptions\Fop\CreditCardInfo;
+use Amadeus\Client\RequestOptions\Fop\CreditCardSupplementaryData;
 use Amadeus\Client\RequestOptions\Fop\DataOrSwitch;
 use Amadeus\Client\RequestOptions\Fop\MopInfo;
+use Amadeus\Client\RequestOptions\Fop\ThreeDSecureInfo;
+use Amadeus\Client\Struct\Fop\AttributeDetails;
 use Amadeus\Client\Struct\Fop\MopDescription;
 use Test\Amadeus\BaseTestCase;
 
@@ -69,5 +73,40 @@ class MopDescriptionTest extends BaseTestCase
         $this->assertEquals('1', $obj->mopDetails->pnrSupplementaryData[0]->dataAndSwitchMap->criteriaDetails[1]->attributeDescription);
         $this->assertEquals('APM', $obj->mopDetails->pnrSupplementaryData[0]->dataAndSwitchMap->criteriaDetails[2]->attributeType);
         $this->assertEquals('1', $obj->mopDetails->pnrSupplementaryData[0]->dataAndSwitchMap->criteriaDetails[2]->attributeDescription);
+    }
+
+    public function testCanConstructWithThreeDSecureVersionTwo()
+    {
+        $mopInfo = new MopInfo([
+            'sequenceNr' => 1,
+            'fopCode' => 'CCVI',
+            'fopType' => 'CC',
+            'fopStatus' => MopInfo::STATUS_NEW,
+            'attributeType' => AttributeDetails::TYPE_FP_ELEMENT,
+            'payMerchant' => 'EW',
+            'mopPaymentType' => MopInfo::MOP_PAY_TYPE_CREDIT_CARD,
+            'creditCardInfo' => new CreditCardInfo([
+                'name' => 'Name Surname',
+                'cardNumber' => 'XXXXXXXXXXXX0003',
+                'vendorCode' => 'VI',
+                'expiryDate' => '1020',
+                'securityId' => '999',
+                'supplementaryData' => [
+                    new CreditCardSupplementaryData([
+                        'setType' => CreditCardSupplementaryData::SET_TYPE_3DS,
+                        'attributeType' => CreditCardSupplementaryData::ATTRIBUTE_TYPE_EXTERNAL_AUTHENTICATION,
+                        'attributeDescription' => CreditCardSupplementaryData::ATTRIBUTE_DESCRIPTION_Y,
+                    ])
+                ],
+                'threeDSecure' => new ThreeDSecureInfo([
+                    'transactionsStatus' => ThreeDSecureInfo::PARES_AUTHENTICATION_SUCCESSFUL
+                ])
+            ])
+        ]);
+
+        $obj = new MopDescription($mopInfo);
+
+        $this->assertSame(AttributeDetails::TYPE_FP_ELEMENT, $obj->paymentModule->groupUsage->attributeDetails[0]->attributeType);
+        $this->assertSame(CreditCardSupplementaryData::SET_TYPE_3DS, $obj->paymentModule->mopDetailedData->creditCardDetailedData->cardSupplementaryData[0]->criteriaSetType);
     }
 }

--- a/tests/Amadeus/Client/Struct/Fop/TdsInformationTest.php
+++ b/tests/Amadeus/Client/Struct/Fop/TdsInformationTest.php
@@ -55,4 +55,29 @@ EOT;
         $this->assertEquals('http://dummy.acs.url', $obj->acsURL->communication->internetAddress);
         $this->assertEquals(Communication::QUAL_WWW, $obj->acsURL->communication->adressQualifier);
     }
+
+    public function testCanConstructWithThreeDSecureVersionTwo()
+    {
+        $options = new ThreeDSecureInfo([
+            'transactionsStatus' => ThreeDSecureInfo::PARES_AUTHENTICATION_SUCCESSFUL,
+            'tdsVersion' => '2.0.1',
+            'creditCardCompany' => ThreeDSecureInfo::CC_COMP_VISA_DIRECTORY_SERVER,
+            'authenticationIndicator' => '05',
+            'tdsServerTransactionId' => 'U0RTRzNTRUczNEdTR1NFUldXRkNXRkRXRUZFRw==',
+            'tdsServerTransactionIdLength' => 28,
+            'directoryServerTransactionId' => 'Q2pENDJ0Tll0WlZ6VFcwSEVvdDVIRGt4TXpFPQ',
+            'directoryServerTransactionIdLength' => 28,
+            'tdsAuthenticationVerificationCode' => 'QUFBQkJYbGprUUFBQUFBRUFXT1JBQUFBQUFBPQ',
+            'tdsAuthenticationVerificationCodeLength' => 28,
+            'tdsAuthenticationVerificationCodeReference' => ThreeDSecureInfo::AUTHENTICATION_VERIFICATION_CODE_VISA
+        ]);
+
+        $obj = new TdsInformation($options);
+
+        $this->assertEquals(ThreeDSecureInfo::PARES_AUTHENTICATION_SUCCESSFUL, $obj->authenticationData->authenticationDataDetails->transStatus);
+        $this->assertEquals('2.0.1', $obj->authenticationData->tdsVersion);
+        $this->assertEquals('U0RTRzNTRUczNEdTR1NFUldXRkNXRkRXRUZFRw==', $obj->tdsBlobData[0]->tdsBlbData->binaryData);
+        $this->assertEquals('QUFBQkJYbGprUUFBQUFBRUFXT1JBQUFBQUFBPQ', $obj->tdsBlobData[1]->tdsBlbData->binaryData);
+        $this->assertEquals('Q2pENDJ0Tll0WlZ6VFcwSEVvdDVIRGt4TXpFPQ', $obj->tdsBlobData[2]->tdsBlbData->binaryData);
+    }
 }


### PR DESCRIPTION
Add 3DS v2 support with external authentication in FOP_CreateFormOfPayment during  Light Ticketing Scope

Light Ticketing implementation guide - Dec 2022 (DOCX)
On Create Form Of Payment Documentation Page
https://developers.amadeus.com/functional-doc/1379
