### PR TITLE
PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ composer.phar
 !conf/.gitkeep
 phpunit.xml
 launch.json
+.phpunit.result.cache

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -30,14 +30,14 @@ build:
       - vendor/bin/phpunit
 
   nodes:
-    php81:
+    php83:
       environment:
-        php: 8.1.13
+        php: 8.3.12
 
     php82:
       environment:
         php: 8.2.24
 
-    php83:
+    php81:
       environment:
-        php: 8.3.12
+        php: 8.1.13

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -32,12 +32,12 @@ build:
   nodes:
     php81:
       environment:
-        php: 8.1
+        php: 8.1.13
 
     php82:
       environment:
-        php: 8.2
+        php: 8.2.24
 
     php83:
       environment:
-        php: 8.3
+        php: 8.3.12

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,32 +1,43 @@
 filter:
-    excluded_paths:
-          - tests/*
-checks:
-    php: true
-coding_style:
-    php:
-        indentation:
-            general:
-                size: 1
-build:
-    tests:
-        override:
-            -
-                command: 'phpunit'
-    nodes:
-        php54:
-            environment:
-                php: 5.4
+  excluded_paths:
+    - 'tests/*'
 
-        php56:
-            environment:
-                php: 5.6
-        php71:
-            environment:
-                php: 7.1
-        php72:
-            environment:
-                php: 7.2
-        php73:
-            environment:
-                php: 7.3
+checks:
+  php:
+    use_self_instead_of_fqcn: true
+    return_doc_comments: true
+    phpunit_assertions: true
+    parameter_doc_comments: true
+    fix_use_statements:
+      remove_unused: true
+      preserve_multiple: false
+      preserve_blanklines: false
+      order_alphabetically: false
+    line_length:
+      max_length: '120'
+    no_goto: true
+    fix_line_ending: true
+
+coding_style:
+  php:
+    indentation:
+      general:
+        size: 1
+
+build:
+  tests:
+    override:
+      - vendor/bin/phpunit
+
+  nodes:
+    php81:
+      environment:
+        php: 8.1
+
+    php82:
+      environment:
+        php: 8.2
+
+    php83:
+      environment:
+        php: 8.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## Unreleased
+## Release 2.0 (Unreleased)
+* Require PHP version 8.1+ for compatibility with modern psr/log^3, and phpunit^9.6
+
+## Unreleased (Before 2.0)
 * Added Support for 3DS v2.0 with external Authentication in FOP_CreateFormOfPayment
 
 ## Release 1.13.0 (5 Apr 2021)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ This library makes it a lot easier for developers to integrate content from the 
 
 # Requirements
 
+## v2
+
+* PHP 8.1 or newer
+* SOAP, XSL and DOM extensions activated
+* A WSDL & authentication details from Amadeus _(SoapHeader 4 or SoapHeader 2)_
+
+## v1
+
 * PHP 5.4 or newer _(tested with 5.4 -> 7.3)_
 * SOAP, XSL and DOM extensions activated
 * A WSDL & authentication details from Amadeus _(SoapHeader 4 or SoapHeader 2)_

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,14 @@
     }
   ],
   "require": {
-    "php": ">=5.4",
+    "php": ">=8.1",
     "ext-soap": "*",
     "ext-dom": "*",
     "ext-xsl": "*",
     "psr/log": "^3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.8.*"
+    "phpunit/phpunit": "^9.5"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "psr/log": "^3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.5"
+    "phpunit/phpunit": "^9.6"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "98950182be775a00aafc41dca2a2977b",
+    "content-hash": "f88f032d0669e8aced50208e8881c3ad",
     "packages": [
         {
             "name": "psr/log",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b8b17dfd0b422ea6f5690f1f19f2fec5",
+    "content-hash": "98950182be775a00aafc41dca2a2977b",
     "packages": [
         {
             "name": "psr/log",
-            "version": "3.0.0",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
                 "shasum": ""
             },
             "require": {
@@ -52,38 +52,38 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.0"
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
-            "time": "2021-07-14T16:46:02+00:00"
+            "time": "2024-09-11T13:17:53+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.5.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^11",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.30 || ^5.4"
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -110,7 +110,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
             },
             "funding": [
                 {
@@ -126,31 +126,147 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:15:36+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "2.0.5",
+            "name": "myclabs/deep-copy",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b"
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
-                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
+                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
-            "suggest": {
-                "dflydev/markdown": "~1.0",
-                "erusev/parsedown": "~1.0"
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.0"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-06-12T14:39:25+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "8eea230464783aa9671db8eea6f8c6ac5285794b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/8eea230464783aa9671db8eea6f8c6ac5285794b",
+                "reference": "8eea230464783aa9671db8eea6f8c6ac5285794b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.3.1"
+            },
+            "time": "2024-10-08T18:51:32+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
@@ -159,127 +275,135 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "phpDocumentor": [
-                        "src/"
-                    ]
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
-                    "name": "Mike van Riel",
-                    "email": "mike.vanriel@naenius.com"
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
                 }
             ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
-                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/release/2.x"
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
             },
-            "time": "2016-01-25T08:17:30+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
         },
         {
-            "name": "phpspec/prophecy",
-            "version": "v1.5.0",
+            "name": "phar-io/version",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "4745ded9307786b730d7a60df5cb5a6c43cf95f7"
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4745ded9307786b730d7a60df5cb5a6c43cf95f7",
-                "reference": "4745ded9307786b730d7a60df5cb5a6c43cf95f7",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "phpdocumentor/reflection-docblock": "~2.0",
-                "sebastian/comparator": "~1.1"
-            },
-            "require-dev": {
-                "phpspec/phpspec": "~2.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4.x-dev"
-                }
-            },
             "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
-                    "name": "Konstantin Kudryashov",
-                    "email": "ever.zet@gmail.com",
-                    "homepage": "http://everzet.com"
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 },
                 {
-                    "name": "Marcello Duarte",
-                    "email": "marcello.duarte@gmail.com"
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
                 }
             ],
-            "description": "Highly opinionated mocking framework for PHP 5.3+",
-            "homepage": "https://github.com/phpspec/prophecy",
-            "keywords": [
-                "Double",
-                "Dummy",
-                "fake",
-                "mock",
-                "spy",
-                "stub"
-            ],
+            "description": "Library for handling version information and constraints",
             "support": {
-                "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/master"
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
-            "time": "2015-08-13T10:07:40+00:00"
+            "time": "2022-02-21T01:04:05+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.2.4",
+            "version": "9.2.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0"
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~4"
+                "phpunit/phpunit": "^9.6"
             },
             "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.2.1",
-                "ext-xmlwriter": "*"
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2.x-dev"
+                    "dev-main": "9.2.x-dev"
                 }
             },
             "autoload": {
@@ -294,7 +418,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -306,33 +430,42 @@
                 "xunit"
             ],
             "support": {
-                "irc": "irc://irc.freenode.net/phpunit",
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/2.2"
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
             },
-            "time": "2015-10-06T15:47:00+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:23:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.5",
+            "version": "3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -347,7 +480,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -358,30 +491,106 @@
                 "iterator"
             ],
             "support": {
-                "irc": "irc://irc.freenode.net/phpunit",
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/1.4.5"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
             },
-            "time": "2017-11-27T13:52:08+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
         },
         {
-            "name": "phpunit/php-text-template",
-            "version": "1.2.1",
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -405,31 +614,42 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/1.2.1"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
             },
-            "time": "2015-06-21T13:50:34+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.8",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
-                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4|~5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -442,7 +662,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -452,103 +672,63 @@
                 "timer"
             ],
             "support": {
-                "irc": "irc://irc.freenode.net/phpunit",
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/master"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
             },
-            "time": "2016-05-12T18:03:57+00:00"
-        },
-        {
-            "name": "phpunit/php-token-stream",
-            "version": "1.4.12",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/1ce90ba27c42e4e44e6d8458241466380b51fa16",
-                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+            "funding": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
                 }
             ],
-            "description": "Wrapper around PHP's tokenizer extension.",
-            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
-            "keywords": [
-                "tokenizer"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
-                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/1.4"
-            },
-            "abandoned": true,
-            "time": "2017-12-04T08:55:13+00:00"
+            "time": "2020-10-26T13:16:10+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.36",
+            "version": "9.6.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517"
+                "reference": "de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/46023de9a91eec7dfb06cc56cb4e260017298517",
-                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa",
+                "reference": "de6abf3b6f8dd955fac3caad3af7a9504e8c2ffa",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-spl": "*",
-                "php": ">=5.3.3",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "~2.1",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.2.2",
-                "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.3",
-                "sebastian/exporter": "~1.2",
-                "sebastian/global-state": "~1.0",
-                "sebastian/version": "~1.0",
-                "symfony/yaml": "~2.1|~3.0"
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.12.0",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.8",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.6",
+                "sebastian/global-state": "^5.0.7",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
             },
             "suggest": {
-                "phpunit/php-invoker": "~1.1"
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "bin": [
                 "phpunit"
@@ -556,10 +736,13 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.8.x-dev"
+                    "dev-master": "9.6-dev"
                 }
             },
             "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
                 "classmap": [
                     "src/"
                 ]
@@ -584,40 +767,49 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/4.8.36"
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.21"
             },
-            "time": "2017-06-21T08:07:12+00:00"
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-19T10:50:18+00:00"
         },
         {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.8",
+            "name": "sebastian/cli-parser",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
-            },
-            "suggest": {
-                "ext-soap": "*"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3.x-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -632,50 +824,48 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
-            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
-                "irc": "irc://irc.freenode.net/phpunit",
-                "issues": "https://github.com/sebastianbergmann/phpunit-mock-objects/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit-mock-objects/tree/2.3"
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
             },
-            "abandoned": true,
-            "time": "2015-10-02T06:51:40+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:27:43+00:00"
         },
         {
-            "name": "sebastian/comparator",
-            "version": "1.2.4",
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2 || ~2.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -688,6 +878,123 @@
                 "BSD-3-Clause"
             ],
             "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
+                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
                 {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
@@ -699,14 +1006,10 @@
                 {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
@@ -714,34 +1017,41 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/1.2"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
             },
-            "time": "2017-01-29T09:50:25+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-09-14T12:41:17+00:00"
         },
         {
-            "name": "sebastian/diff",
-            "version": "1.4.1",
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -755,49 +1065,118 @@
             ],
             "authors": [
                 {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
                 {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
                 }
             ],
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/master"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
             },
-            "time": "2015-12-08T07:14:41+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:30:58+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.7",
+            "version": "5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716"
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/4e8f0da10ac5802913afc151413bc8c53b6c2716",
-                "reference": "4e8f0da10ac5802913afc151413bc8c53b6c2716",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "5.1-dev"
                 }
             },
             "autoload": {
@@ -824,36 +1203,42 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/1.3.7"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
             },
-            "time": "2016-05-17T03:18:57+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:03:51+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.2",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/78c00df8f170e02473b682df15bfcdacc3d32d72",
+                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -867,6 +1252,10 @@
             ],
             "authors": [
                 {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
                 },
@@ -875,49 +1264,54 @@
                     "email": "github@wallbash.com"
                 },
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
                     "name": "Adam Harvey",
                     "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
             "keywords": [
                 "export",
                 "exporter"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/master"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.6"
             },
-            "time": "2016-06-17T09:04:28+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:33:00+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.1",
+            "version": "5.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -925,7 +1319,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -950,34 +1344,41 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/1.1.1"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
             },
-            "time": "2015-10-12T03:26:01+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:35:11+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "1.0.5",
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7"
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
-                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -991,12 +1392,180 @@
             ],
             "authors": [
                 {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
                 {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
                 },
                 {
                     "name": "Adam Harvey",
@@ -1004,28 +1573,152 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/master"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
             },
-            "time": "2016-10-03T07:41:43+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:07:39+00:00"
         },
         {
-            "name": "sebastian/version",
-            "version": "1.0.6",
+            "name": "sebastian/resource-operations",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T16:00:52+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:13:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1046,159 +1739,65 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/1.0.6"
-            },
-            "time": "2015-06-21T13:59:46+00:00"
-        },
-        {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.30.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "0424dff1c58f028c451efff2045f5d92410bd540"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/0424dff1c58f028c451efff2045f5d92410bd540",
-                "reference": "0424dff1c58f028c451efff2045f5d92410bd540",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "provide": {
-                "ext-ctype": "*"
-            },
-            "suggest": {
-                "ext-ctype": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.30.0"
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
             },
             "funding": [
                 {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
+                    "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T15:07:36+00:00"
+            "time": "2020-09-28T06:39:44+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v3.4.47",
+            "name": "theseer/tokenizer",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "88289caa3c166321883f67fe5130188ebbb47094"
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/88289caa3c166321883f67fe5130188ebbb47094",
-                "reference": "88289caa3c166321883f67fe5130188ebbb47094",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/polyfill-ctype": "~1.8"
-            },
-            "conflict": {
-                "symfony/console": "<3.4"
-            },
-            "require-dev": {
-                "symfony/console": "~3.4|~4.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
+                "classmap": [
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 }
             ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v3.4.47"
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
             },
             "funding": [
                 {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
+                    "url": "https://github.com/theseer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T10:57:07+00:00"
+            "time": "2024-03-03T12:36:25+00:00"
         }
     ],
     "aliases": [],
@@ -1207,7 +1806,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.4",
+        "php": ">=8.1",
         "ext-soap": "*",
         "ext-dom": "*",
         "ext-xsl": "*"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./tests/bootstrap.php"
-         colors="true">
-    <testsuites>
-        <testsuite>
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-                <directory>./vendor</directory>
-                <directory>./tests</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-<!--    <logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="./tests/bootstrap.php"
+         colors="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+>
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+      <directory>./tests</directory>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="Main">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <!--    <logging>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>
 -->

--- a/src/Amadeus/Client/Params/SessionHandlerParams.php
+++ b/src/Amadeus/Client/Params/SessionHandlerParams.php
@@ -33,7 +33,6 @@ use Psr\Log\LoggerInterface;
  */
 class SessionHandlerParams
 {
-
     /**
      * Full file & path to the WSDL file to be used
      *

--- a/src/Amadeus/Client/RequestOptions/Fare/MPPassenger.php
+++ b/src/Amadeus/Client/RequestOptions/Fare/MPPassenger.php
@@ -43,10 +43,10 @@ class MPPassenger extends LoadParamsFromArray
     const TYPE_STUDENT = "ST";
 
     const TYPE_INDIVIDUAL_INCLUSIVE_TOUR = 'IIT';
-	
-	const TYPE_YOUTH = "YTH";
-	
-	const TYPE_SENIOR = "SRC";
+
+    const TYPE_YOUTH = "YTH";
+
+    const TYPE_SENIOR = "SRC";
 
     /**
      * What type of passengers? self::TYPE_*

--- a/src/Amadeus/Client/RequestOptions/FareMasterPricerTbSearch.php
+++ b/src/Amadeus/Client/RequestOptions/FareMasterPricerTbSearch.php
@@ -32,7 +32,6 @@ use Amadeus\Client\RequestOptions\FareMasterPricerExSearchOptions as FareMasterP
  */
 class FareMasterPricerTbSearch extends FareMasterPricerExSearchOptions
 {
-
     /**
      * Set to true to disallow connecting flight to change airports within a city.
      *

--- a/src/Amadeus/Client/RequestOptions/Fop/MopInfo.php
+++ b/src/Amadeus/Client/RequestOptions/Fop/MopInfo.php
@@ -67,7 +67,7 @@ class MopInfo extends LoadParamsFromArray
      * Must be set to 1 if there is only 1 FOP in the FP line.
      * Must be set to 0 if this is an old FOP
      *
-     * @var int
+     * @var int|null
      */
     public $sequenceNr;
 

--- a/src/Amadeus/Client/RequestOptions/MpBaseOptions.php
+++ b/src/Amadeus/Client/RequestOptions/MpBaseOptions.php
@@ -63,14 +63,14 @@ class MpBaseOptions extends Base
      *
      * Must match the data present in $this->passengers
      *
-     * @var int
+     * @var int|null
      */
     public $nrOfRequestedPassengers;
 
     /**
      * Maximum number of recommendations requested
      *
-     * @var int
+     * @var int|null
      */
     public $nrOfRequestedResults;
 
@@ -152,7 +152,7 @@ class MpBaseOptions extends Base
     /**
      * Optional. Weights for Multi Ticket functionality.
      *
-     * @var Fare\MasterPricer\MultiTicketWeights
+     * @var Fare\MasterPricer\MultiTicketWeights|null
      */
     public $multiTicketWeights;
 

--- a/src/Amadeus/Client/RequestOptions/Pnr/Traveller.php
+++ b/src/Amadeus/Client/RequestOptions/Pnr/Traveller.php
@@ -41,10 +41,10 @@ class Traveller extends LoadParamsFromArray
     const TRAV_TYPE_INFANT_WITH_SEAT = "INS";
 
     const TRAV_TYPE_STUDENT = "STU";
-	
-	const TRAV_TYPE_YOUTH = "YTH";
-	
-	const TRAV_TYPE_SENIOR = "SRC";
+
+    const TRAV_TYPE_YOUTH = "YTH";
+
+    const TRAV_TYPE_SENIOR = "SRC";
 
     /**
      * Unique sequence number for traveller

--- a/src/Amadeus/Client/ResponseHandler/StandardResponseHandler.php
+++ b/src/Amadeus/Client/ResponseHandler/StandardResponseHandler.php
@@ -257,12 +257,12 @@ abstract class StandardResponseHandler implements MessageResponseHandler
     protected function loadDomDocument($response)
     {
         $domDoc = new \DOMDocument('1.0', 'UTF-8');
-        $loadResult = false;
 
         try {
             $loadResult = $domDoc->loadXML($response);
         } catch (\Throwable) {
             // swallow to throw exception below
+            $loadResult = false;
         }
 
         if ($loadResult === false) {

--- a/src/Amadeus/Client/ResponseHandler/StandardResponseHandler.php
+++ b/src/Amadeus/Client/ResponseHandler/StandardResponseHandler.php
@@ -257,8 +257,14 @@ abstract class StandardResponseHandler implements MessageResponseHandler
     protected function loadDomDocument($response)
     {
         $domDoc = new \DOMDocument('1.0', 'UTF-8');
+        $loadResult = false;
 
-        $loadResult = $domDoc->loadXML($response);
+        try {
+            $loadResult = $domDoc->loadXML($response);
+        } catch (\Throwable) {
+            // swallow to throw exception below
+        }
+
         if ($loadResult === false) {
             throw new Exception('Could not load response message into DOMDocument');
         }

--- a/src/Amadeus/Client/Session/Handler/SoapHeader4.php
+++ b/src/Amadeus/Client/Session/Handler/SoapHeader4.php
@@ -307,7 +307,7 @@ class SoapHeader4 extends Base
             //Generate nonce, msg creation string & password digest:
             $password = base64_decode($params->authParams->passwordData);
             $creation = new \DateTime('now', new \DateTimeZone('UTC'));
-            $t = microtime(true);
+            $t = (float)microtime(true);
             $micro = sprintf("%03d", ($t - floor($t)) * 1000);
             $creationString = $this->createDateTimeStringForAuth($creation, $micro);
             $messageNonce = $this->generateUniqueNonce($params->authParams->nonceBase, $creationString);
@@ -442,7 +442,7 @@ class SoapHeader4 extends Base
      */
     protected function generateSecurityHeaderRawXml($originator, $nonce, $pwDigest, $creationTimeString)
     {
-        return $xml = '<oas:Security xmlns:oas="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
+        return '<oas:Security xmlns:oas="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
 	<oas:UsernameToken xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" oas1:Id="UsernameToken-1">
 		<oas:Username>' . $originator . '</oas:Username>
 		<oas:Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">' . $nonce . '</oas:Nonce>

--- a/src/Amadeus/Client/Session/Handler/WsdlAnalyser.php
+++ b/src/Amadeus/Client/Session/Handler/WsdlAnalyser.php
@@ -170,12 +170,12 @@ class WsdlAnalyser
         $domXpath = null;
 
         $importPath = realpath(dirname($wsdlPath)).DIRECTORY_SEPARATOR.$import;
-        $wsdlContent = false;
 
         try {
             $wsdlContent = file_get_contents($importPath);
         } catch (\Throwable) {
             // swallow to throw exception below
+            $wsdlContent = false;
         }
 
         if ($wsdlContent !== false) {
@@ -226,12 +226,11 @@ class WsdlAnalyser
     public static function loadWsdlXpath($wsdlFilePath, $wsdlId)
     {
         if (!isset(self::$wsdlDomXpath[$wsdlId]) || is_null(self::$wsdlDomXpath[$wsdlId])) {
-            $wsdlContent = false;
-
             try {
                 $wsdlContent = file_get_contents($wsdlFilePath);
             } catch (\Throwable) {
                 // swallow to throw exception below
+                $wsdlContent = false;
             }
 
             if ($wsdlContent !== false) {

--- a/src/Amadeus/Client/Session/Handler/WsdlAnalyser.php
+++ b/src/Amadeus/Client/Session/Handler/WsdlAnalyser.php
@@ -170,7 +170,13 @@ class WsdlAnalyser
         $domXpath = null;
 
         $importPath = realpath(dirname($wsdlPath)).DIRECTORY_SEPARATOR.$import;
-        $wsdlContent = file_get_contents($importPath);
+        $wsdlContent = false;
+
+        try {
+            $wsdlContent = file_get_contents($importPath);
+        } catch (\Throwable) {
+            // swallow to throw exception below
+        }
 
         if ($wsdlContent !== false) {
             $domDoc = new \DOMDocument('1.0', 'UTF-8');
@@ -220,7 +226,13 @@ class WsdlAnalyser
     public static function loadWsdlXpath($wsdlFilePath, $wsdlId)
     {
         if (!isset(self::$wsdlDomXpath[$wsdlId]) || is_null(self::$wsdlDomXpath[$wsdlId])) {
-            $wsdlContent = file_get_contents($wsdlFilePath);
+            $wsdlContent = false;
+
+            try {
+                $wsdlContent = file_get_contents($wsdlFilePath);
+            } catch (\Throwable) {
+                // swallow to throw exception below
+            }
 
             if ($wsdlContent !== false) {
                 self::$wsdlDomDoc[$wsdlId] = new \DOMDocument('1.0', 'UTF-8');

--- a/src/Amadeus/Client/SoapClient.php
+++ b/src/Amadeus/Client/SoapClient.php
@@ -90,9 +90,7 @@ class SoapClient extends \SoapClient implements Log\LoggerAwareInterface
      */
     protected function transformIncomingRequest($request)
     {
-        $newRequest = null;
-
-        $xsltFile = dirname(__FILE__).DIRECTORY_SEPARATOR.self::REMOVE_EMPTY_XSLT_LOCATION;
+        $xsltFile = __DIR__ .DIRECTORY_SEPARATOR.self::REMOVE_EMPTY_XSLT_LOCATION;
         if (!is_readable($xsltFile)) {
             throw new Exception('XSLT file "'.$xsltFile.'" is not readable!');
         }
@@ -108,7 +106,7 @@ class SoapClient extends \SoapClient implements Log\LoggerAwareInterface
         $transform = $processor->transformToXml($dom);
         if ($transform === false) {
             //On transform error: usually when modifying the XSLT transformation incorrectly...
-            $this->logger->log(
+            $this->logger?->log(
                 Log\LogLevel::ERROR,
                 __METHOD__."__doRequest(): XSLTProcessor::transformToXml "
                 . "returned FALSE: could not perform transformation!!"

--- a/src/Amadeus/Client/Struct/Fare/BaseMasterPricerMessage.php
+++ b/src/Amadeus/Client/Struct/Fare/BaseMasterPricerMessage.php
@@ -107,7 +107,7 @@ class BaseMasterPricerMessage extends BaseWsMessage
     {
         if (is_int($options->nrOfRequestedPassengers) ||
             is_int($options->nrOfRequestedResults) ||
-            $options->multiTicketWeights instanceof MultiTicketWeights
+            $options->multiTicketWeights !== null
         ) {
             $this->numberOfUnit = new MasterPricer\NumberOfUnit(
                 $options->nrOfRequestedPassengers,

--- a/src/Amadeus/Client/Struct/Fare/MasterPricer/PaxReference.php
+++ b/src/Amadeus/Client/Struct/Fare/MasterPricer/PaxReference.php
@@ -46,7 +46,7 @@ class PaxReference
     /**
      * @param int $mainTravellerRef
      * @param boolean $isInfant (OPTIONAL)
-     * @param string|null $passengerType (OPTIONAL)
+     * @param string|string[]|null $passengerType (OPTIONAL)
      */
     public function __construct($mainTravellerRef, $isInfant = false, $passengerType = null)
     {

--- a/src/Amadeus/Client/Struct/Fare/MasterPricerExpertSearch.php
+++ b/src/Amadeus/Client/Struct/Fare/MasterPricerExpertSearch.php
@@ -37,7 +37,6 @@ use Amadeus\Client\Struct\Fare\MasterPricer;
  */
 class MasterPricerExpertSearch extends BaseMasterPricerMessage
 {
-
     /**
      * @var mixed
      */

--- a/src/Amadeus/Client/Struct/Fare/PricePnr13/CarrierInformation.php
+++ b/src/Amadeus/Client/Struct/Fare/PricePnr13/CarrierInformation.php
@@ -30,7 +30,6 @@ namespace Amadeus\Client\Struct\Fare\PricePnr13;
  */
 class CarrierInformation
 {
-
     /**
      * @var CompanyIdentification
      */

--- a/src/Amadeus/Client/Struct/Fop/AuthenticationDataDetails.php
+++ b/src/Amadeus/Client/Struct/Fop/AuthenticationDataDetails.php
@@ -30,7 +30,6 @@ namespace Amadeus\Client\Struct\Fop;
  */
 class AuthenticationDataDetails
 {
-
     /**
      * E Error message received from directory server (Internal status)
      * N Card holder not participating

--- a/src/Amadeus/Client/Struct/Fop/MopDescription.php
+++ b/src/Amadeus/Client/Struct/Fop/MopDescription.php
@@ -128,7 +128,6 @@ class MopDescription extends WsMessageUtility
             $options->payIds,
             $options->paySupData
         )) {
-
             /**
              * for backwards compatibility use `$options->fopType` as default for `$attributeType`
              */

--- a/src/Amadeus/Client/Struct/Fop/TdsBlbData.php
+++ b/src/Amadeus/Client/Struct/Fop/TdsBlbData.php
@@ -59,12 +59,12 @@ class TdsBlbData
      *
      * @param string $binaryData
      * @param string $dataType
-     * @param int|null $dataLength
+     * @param int|string|null $dataLength
      */
     public function __construct($binaryData, $dataType, $dataLength)
     {
         if (!is_null($dataLength)) {
-            $this->dataLength = $dataLength;
+            $this->dataLength = (int)$dataLength;
         } else {
             $this->dataLength = mb_strlen(base64_decode($binaryData));
         }

--- a/src/Amadeus/Client/Struct/Fop/TdsBlobData.php
+++ b/src/Amadeus/Client/Struct/Fop/TdsBlobData.php
@@ -46,7 +46,7 @@ class TdsBlobData
      * @param string $id
      * @param string $data
      * @param string $dataType
-     * @param int|null $length
+     * @param int|string|null $length
      */
     public function __construct($id, $data, $dataType, $length)
     {

--- a/src/Amadeus/Client/Struct/Pnr/AddMultiElements/CommissionInfo.php
+++ b/src/Amadeus/Client/Struct/Pnr/AddMultiElements/CommissionInfo.php
@@ -30,7 +30,6 @@ namespace Amadeus\Client\Struct\Pnr\AddMultiElements;
  */
 class CommissionInfo
 {
-
     /**
      * @var int
      */

--- a/src/Amadeus/Client/Struct/Pnr/AddMultiElements/FareElement.php
+++ b/src/Amadeus/Client/Struct/Pnr/AddMultiElements/FareElement.php
@@ -31,7 +31,6 @@ namespace Amadeus\Client\Struct\Pnr\AddMultiElements;
 
 class FareElement
 {
-
     /**
      * @var string
      */

--- a/src/Amadeus/Client/Struct/PriceXplorer/NumberOfUnitDetailsType.php
+++ b/src/Amadeus/Client/Struct/PriceXplorer/NumberOfUnitDetailsType.php
@@ -30,7 +30,6 @@ namespace Amadeus\Client\Struct\PriceXplorer;
  */
 class NumberOfUnitDetailsType
 {
-
     /*
      * https://webservices.amadeus.com/extranet/structures/viewMessageStructure.do?id=2338&serviceVersionId=2304&isQuery=true#
      *     CNS     Cheapest non-stop

--- a/src/Amadeus/Client/Struct/Service/IntegratedPricing/DocumentDetails.php
+++ b/src/Amadeus/Client/Struct/Service/IntegratedPricing/DocumentDetails.php
@@ -30,7 +30,6 @@ namespace Amadeus\Client\Struct\Service\IntegratedPricing;
  */
 class DocumentDetails
 {
-
     /**
      * @var string
      */

--- a/src/Amadeus/Client/Struct/Service/StandaloneCatalogue.php
+++ b/src/Amadeus/Client/Struct/Service/StandaloneCatalogue.php
@@ -38,7 +38,6 @@ use Amadeus\Client\Struct\Fare\PricePNRWithBookingClass13;
  */
 class StandaloneCatalogue extends BaseWsMessage
 {
-
     /**
      *
      * @var PassengerInfoGroup[]

--- a/src/Amadeus/Client/Struct/Service/StandaloneCatalogue/FareInfo.php
+++ b/src/Amadeus/Client/Struct/Service/StandaloneCatalogue/FareInfo.php
@@ -29,7 +29,6 @@ namespace Amadeus\Client\Struct\Service\StandaloneCatalogue;
  */
 class FareInfo
 {
-
     /**
      *
      * @var string

--- a/src/Amadeus/Client/Struct/Service/StandaloneCatalogue/PassengerInfoGroup.php
+++ b/src/Amadeus/Client/Struct/Service/StandaloneCatalogue/PassengerInfoGroup.php
@@ -32,7 +32,6 @@ use Amadeus\Client\RequestOptions\Fare\InformativePricing\Passenger;
  */
 class PassengerInfoGroup
 {
-
     /**
      *
      * @var specificTravellerDetails

--- a/src/Amadeus/Client/Struct/Service/StandaloneCatalogue/SpecificTravellerDetails.php
+++ b/src/Amadeus/Client/Struct/Service/StandaloneCatalogue/SpecificTravellerDetails.php
@@ -30,7 +30,6 @@ namespace Amadeus\Client\Struct\Service\StandaloneCatalogue;
  */
 class SpecificTravellerDetails
 {
-
     /**
      *
      * @var specificTravellerDetails[]

--- a/src/Amadeus/Client/Struct/Service/StandaloneCatalogue/TravellerDetails.php
+++ b/src/Amadeus/Client/Struct/Service/StandaloneCatalogue/TravellerDetails.php
@@ -29,7 +29,6 @@ namespace Amadeus\Client\Struct\Service\StandaloneCatalogue;
  */
 class TravellerDetails
 {
-
     /**
      *
      * @var int

--- a/src/Amadeus/Client/Struct/Ticket/ProcessEDoc/DocInfo.php
+++ b/src/Amadeus/Client/Struct/Ticket/ProcessEDoc/DocInfo.php
@@ -20,7 +20,7 @@
  * @license https://opensource.org/licenses/Apache-2.0 Apache 2.0
  */
 
- namespace Amadeus\Client\Struct\Ticket\ProcessEDoc;
+namespace Amadeus\Client\Struct\Ticket\ProcessEDoc;
 
 /**
  * DocInfo

--- a/src/Amadeus/Client/Struct/Ticket/RetrieveListOfTSM/DeadIndicator.php
+++ b/src/Amadeus/Client/Struct/Ticket/RetrieveListOfTSM/DeadIndicator.php
@@ -30,7 +30,6 @@ namespace Amadeus\Client\Struct\Ticket\RetrieveListOfTSM;
  */
 class DeadIndicator
 {
-    
     /**
      * @var StatusDetails
      */

--- a/tests/Amadeus/BaseTestCase.php
+++ b/tests/Amadeus/BaseTestCase.php
@@ -22,12 +22,14 @@
 
 namespace Test\Amadeus;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * BaseTestCase
  *
  * @package Test\Amadeus
  */
-class BaseTestCase extends \PHPUnit_Framework_TestCase
+class BaseTestCase extends TestCase
 {
     /**
      * Get a protected or private method from given class

--- a/tests/Amadeus/Client/Params/SessionHandlerParamsTest.php
+++ b/tests/Amadeus/Client/Params/SessionHandlerParamsTest.php
@@ -113,7 +113,7 @@ class SessionHandlerParamsTest extends BaseTestCase
             ]
         ]);
 
-        $this->assertInternalType('array', $par->soapClientOptions);
+        $this->assertIsArray($par->soapClientOptions);
         $this->assertNotEmpty($par->soapClientOptions);
         $this->assertEquals(
             SOAP_COMPRESSION_ACCEPT | SOAP_COMPRESSION_GZIP,

--- a/tests/Amadeus/Client/ParamsTest.php
+++ b/tests/Amadeus/Client/ParamsTest.php
@@ -65,7 +65,7 @@ class ParamsTest extends BaseTestCase
         $this->assertInstanceOf('Amadeus\Client\Params\SessionHandlerParams', $params->sessionHandlerParams);
         $this->assertTrue($params->sessionHandlerParams->stateful);
         $this->assertInstanceOf('Psr\Log\LoggerInterface', $params->sessionHandlerParams->logger);
-        $this->assertInternalType('array', $params->sessionHandlerParams->wsdl);
+        $this->assertIsArray($params->sessionHandlerParams->wsdl);
         $this->assertCount(1, $params->sessionHandlerParams->wsdl);
         $this->assertEquals('/var/fake/file/path', $params->sessionHandlerParams->wsdl[0]);
 
@@ -135,7 +135,7 @@ class ParamsTest extends BaseTestCase
         $this->assertInstanceOf('Amadeus\Client\Params\SessionHandlerParams', $params->sessionHandlerParams);
         $this->assertTrue($params->sessionHandlerParams->stateful);
         $this->assertInstanceOf('Psr\Log\LoggerInterface', $params->sessionHandlerParams->logger);
-        $this->assertInternalType('array', $params->sessionHandlerParams->wsdl);
+        $this->assertIsArray($params->sessionHandlerParams->wsdl);
         $this->assertCount(1, $params->sessionHandlerParams->wsdl);
         $this->assertEquals('/var/fake/file/path', $params->sessionHandlerParams->wsdl[0]);
 
@@ -179,7 +179,7 @@ class ParamsTest extends BaseTestCase
         $this->assertInstanceOf('Amadeus\Client\Params\SessionHandlerParams', $params->sessionHandlerParams);
         $this->assertTrue($params->sessionHandlerParams->stateful);
         $this->assertInstanceOf('Psr\Log\LoggerInterface', $params->sessionHandlerParams->logger);
-        $this->assertInternalType('array', $params->sessionHandlerParams->wsdl);
+        $this->assertIsArray($params->sessionHandlerParams->wsdl);
         $this->assertCount(1, $params->sessionHandlerParams->wsdl);
         $this->assertEquals('/var/fake/file/path', $params->sessionHandlerParams->wsdl[0]);
 
@@ -233,9 +233,9 @@ class ParamsTest extends BaseTestCase
 
     public function testCanCreateParamsWithOverrideSessionHandlerAndRequestCreator()
     {
-        $dummySessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
-        $dummyRequestCreator = $this->getMockBuilder('Amadeus\Client\RequestCreator\RequestCreatorInterface')->getMock();
-        $dummyResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $dummySessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
+        $dummyRequestCreator = $this->createMock('Amadeus\Client\RequestCreator\RequestCreatorInterface');
+        $dummyResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $theParamArray = [
             'sessionHandler' => $dummySessionHandler,

--- a/tests/Amadeus/Client/ResponseHandler/BaseTest.php
+++ b/tests/Amadeus/Client/ResponseHandler/BaseTest.php
@@ -22,6 +22,7 @@
 
 namespace Test\Amadeus\Client\ResponseHandler;
 
+use Amadeus\Client\Exception;
 use Amadeus\Client\ResponseHandler;
 use Amadeus\Client\Result;
 use Amadeus\Client\Session\Handler\SendResult;
@@ -1720,19 +1721,14 @@ class BaseTest extends BaseTestCase
 
     public function testCanHandleInvalidXmlDocument()
     {
-        $this->setExpectedException('Amadeus\Client\Exception');
+        $this->expectException(Exception::class);
 
         $respHandler = new ResponseHandler\Base();
 
         $sendResult = new SendResult();
         $sendResult->responseXml = $this->getTestFile('dummyInvalidXmlDocument.txt');
 
-        $warningEnabledOrig = \PHPUnit_Framework_Error_Warning::$enabled;
-        \PHPUnit_Framework_Error_Warning::$enabled = false;
-
         $respHandler->analyzeResponse($sendResult, 'Fare_PricePnrWithBookingClass');
-
-        \PHPUnit_Framework_Error_Warning::$enabled = $warningEnabledOrig;
     }
 
     public function testCanHandleCommandCryptic()

--- a/tests/Amadeus/Client/Session/Handler/HandlerFactoryTest.php
+++ b/tests/Amadeus/Client/Session/Handler/HandlerFactoryTest.php
@@ -38,7 +38,7 @@ class HandlerFactoryTest extends BaseTestCase
 
     public function testCreateWithoutAuthWillThrowException()
     {
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
 
         $params = $par = new SessionHandlerParams([
             'wsdl' => '/dummy/path',
@@ -121,7 +121,7 @@ class HandlerFactoryTest extends BaseTestCase
 
     public function testCreateSoapHeader1WillThrowException()
     {
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
 
         $params = $par = new SessionHandlerParams([
             'wsdl' => '/dummy/path',

--- a/tests/Amadeus/Client/Session/Handler/SoapHeader2Test.php
+++ b/tests/Amadeus/Client/Session/Handler/SoapHeader2Test.php
@@ -24,6 +24,7 @@ namespace Amadeus\Client\Session\Handler;
 
 use Amadeus\Client;
 use Amadeus\Client\Params\SessionHandlerParams;
+use Amadeus\Client\SoapClient;
 use Psr\Log\NullLogger;
 use Test\Amadeus\BaseTestCase;
 
@@ -38,7 +39,7 @@ class SoapHeader2Test extends BaseTestCase
 
     public function testCanTrySendMessageWhenNotAuthenticated()
     {
-        $this->setExpectedException('Amadeus\Client\Session\Handler\InvalidSessionException');
+        $this->expectException(InvalidSessionException::class);
 
         $handler = new SoapHeader2($this->makeSessionHandlerParams());
 
@@ -54,13 +55,9 @@ class SoapHeader2Test extends BaseTestCase
 
     public function testCanTryPrepareNextMessageWhenAuthenticated()
     {
-        $overrideSoapClient = $this->getMock(
-            'Amadeus\Client\SoapClient',
-            ['__getLastRequest', '__getLastResponse', 'PNR_Retrieve'],
-            [],
-            '',
-            false
-        );
+        $overrideSoapClient = $this->getMockBuilder(SoapClient::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $dummyPnrRequest = $this->getTestFile('dummyPnrRequestsoapheader2.txt');
         $dummyPnrReply = $this->getTestFile('dummyPnrReplysoapheader2.txt');
@@ -80,7 +77,8 @@ class SoapHeader2Test extends BaseTestCase
 
         $overrideSoapClient
             ->expects($this->any())
-            ->method('PNR_Retrieve')
+            ->method('__call')
+            ->with('PNR_Retrieve')
             ->will($this->returnValue($dummyPnrResponseObject));
 
         $handler = new SoapHeader2($this->makeSessionHandlerParams(
@@ -111,13 +109,9 @@ class SoapHeader2Test extends BaseTestCase
 
     public function testCanSendAuthCallAndStartSession()
     {
-        $overrideSoapClient = $this->getMock(
-            'Amadeus\Client\SoapClient',
-            ['__getLastRequest', '__getLastResponse', 'Security_Authenticate'],
-            [],
-            '',
-            false
-        );
+        $overrideSoapClient = $this->getMockBuilder(SoapClient::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $dummyRequest = $this->getTestFile('soapheader2' . DIRECTORY_SEPARATOR . 'dummySecurityAuth.txt');
         $dummyReply = $this->getTestFile('soapheader2' . DIRECTORY_SEPARATOR . 'dummySecurityAuthReply.txt');
@@ -145,7 +139,8 @@ class SoapHeader2Test extends BaseTestCase
 
         $overrideSoapClient
             ->expects($this->any())
-            ->method('Security_Authenticate')
+            ->method('__call')
+            ->with('Security_Authenticate')
             ->will($this->returnValue($wsResponse));
 
         $handlerParams = $this->makeSessionHandlerParams(
@@ -218,7 +213,7 @@ class SoapHeader2Test extends BaseTestCase
 
     public function testSetStatelessNotSupported()
     {
-        $this->setExpectedException('\Amadeus\Client\Session\Handler\UnsupportedOperationException');
+        $this->expectException(UnsupportedOperationException::class);
 
         $sessionHandler = new SoapHeader2($this->makeSessionHandlerParams());
 
@@ -236,7 +231,7 @@ class SoapHeader2Test extends BaseTestCase
 
     public function testSetTflNotSupported()
     {
-        $this->setExpectedException('\Amadeus\Client\Session\Handler\UnsupportedOperationException');
+        $this->expectException(UnsupportedOperationException::class);
 
         $sessionHandler = new SoapHeader2($this->makeSessionHandlerParams());
 
@@ -254,7 +249,7 @@ class SoapHeader2Test extends BaseTestCase
 
     public function testSetConsumerIdNotSupported()
     {
-        $this->setExpectedException('\Amadeus\Client\Session\Handler\UnsupportedOperationException');
+        $this->expectException(UnsupportedOperationException::class);
 
         $sessionHandler = new SoapHeader2($this->makeSessionHandlerParams());
 

--- a/tests/Amadeus/Client/Session/Handler/SoapHeader4Test.php
+++ b/tests/Amadeus/Client/Session/Handler/SoapHeader4Test.php
@@ -25,6 +25,7 @@ namespace Test\Amadeus\Client\Session\Handler;
 use Amadeus\Client;
 use Amadeus\Client\Params\SessionHandlerParams;
 use Amadeus\Client\Session\Handler\SoapHeader4;
+use Amadeus\Client\SoapClient;
 use Psr\Log\NullLogger;
 use Test\Amadeus\BaseTestCase;
 
@@ -66,17 +67,17 @@ xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-u
             $this->assertInstanceOf('\SoapHeader', $tmp);
         }
 
-        $this->assertInternalType('string', $result[0]->data);
+        $this->assertIsString($result[0]->data);
         $this->assertTrue($this->isValidGuid($result[0]->data));
         $this->assertEquals('MessageID', $result[0]->name);
         $this->assertEquals('http://www.w3.org/2005/08/addressing', $result[0]->namespace);
 
-        $this->assertInternalType('string', $result[1]->data);
+        $this->assertIsString($result[1]->data);
         $this->assertEquals('http://webservices.amadeus.com/PNRRET_11_3_1A', $result[1]->data);
         $this->assertEquals('Action', $result[1]->name);
         $this->assertEquals('http://www.w3.org/2005/08/addressing', $result[1]->namespace);
 
-        $this->assertInternalType('string', $result[2]->data);
+        $this->assertIsString($result[2]->data);
         $this->assertEquals('https://dummy.webservices.endpoint.com/SOAPADDRESS', $result[2]->data);
         $this->assertEquals('To', $result[2]->name);
         $this->assertEquals('http://www.w3.org/2005/08/addressing', $result[2]->namespace);
@@ -128,17 +129,17 @@ xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-u
             $this->assertInstanceOf('\SoapHeader', $tmp);
         }
 
-        $this->assertInternalType('string', $result[0]->data);
+        $this->assertIsString($result[0]->data);
         $this->assertTrue($this->isValidGuid($result[0]->data));
         $this->assertEquals('MessageID', $result[0]->name);
         $this->assertEquals('http://www.w3.org/2005/08/addressing', $result[0]->namespace);
 
-        $this->assertInternalType('string', $result[1]->data);
+        $this->assertIsString($result[1]->data);
         $this->assertEquals('http://webservices.amadeus.com/PNRRET_11_3_1A', $result[1]->data);
         $this->assertEquals('Action', $result[1]->name);
         $this->assertEquals('http://www.w3.org/2005/08/addressing', $result[1]->namespace);
 
-        $this->assertInternalType('string', $result[2]->data);
+        $this->assertIsString($result[2]->data);
         $this->assertEquals('https://dummy.webservices.endpoint.com/SOAPADDRESS', $result[2]->data);
         $this->assertEquals('To', $result[2]->name);
         $this->assertEquals('http://www.w3.org/2005/08/addressing', $result[2]->namespace);
@@ -186,17 +187,17 @@ xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-u
             $this->assertInstanceOf('\SoapHeader', $tmp);
         }
 
-        $this->assertInternalType('string', $result[0]->data);
+        $this->assertIsString($result[0]->data);
         $this->assertTrue($this->isValidGuid($result[0]->data));
         $this->assertEquals('MessageID', $result[0]->name);
         $this->assertEquals('http://www.w3.org/2005/08/addressing', $result[0]->namespace);
 
-        $this->assertInternalType('string', $result[1]->data);
+        $this->assertIsString($result[1]->data);
         $this->assertEquals('http://webservices.amadeus.com/PNRRET_11_3_1A', $result[1]->data);
         $this->assertEquals('Action', $result[1]->name);
         $this->assertEquals('http://www.w3.org/2005/08/addressing', $result[1]->namespace);
 
-        $this->assertInternalType('string', $result[2]->data);
+        $this->assertIsString($result[2]->data);
         $this->assertEquals('https://dummy.webservices.endpoint.com/SOAPADDRESS', $result[2]->data);
         $this->assertEquals('To', $result[2]->name);
         $this->assertEquals('http://www.w3.org/2005/08/addressing', $result[2]->namespace);
@@ -239,17 +240,17 @@ xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-u
             $this->assertInstanceOf('\SoapHeader', $tmp);
         }
 
-        $this->assertInternalType('string', $result[0]->data);
+        $this->assertIsString($result[0]->data);
         $this->assertTrue($this->isValidGuid($result[0]->data));
         $this->assertEquals('MessageID', $result[0]->name);
         $this->assertEquals('http://www.w3.org/2005/08/addressing', $result[0]->namespace);
 
-        $this->assertInternalType('string', $result[1]->data);
+        $this->assertIsString($result[1]->data);
         $this->assertEquals('http://webservices.amadeus.com/PNRRET_11_3_1A', $result[1]->data);
         $this->assertEquals('Action', $result[1]->name);
         $this->assertEquals('http://www.w3.org/2005/08/addressing', $result[1]->namespace);
 
-        $this->assertInternalType('string', $result[2]->data);
+        $this->assertIsString($result[2]->data);
         $this->assertEquals('https://dummy.webservices.endpoint.com/SOAPADDRESS', $result[2]->data);
         $this->assertEquals('To', $result[2]->name);
         $this->assertEquals('http://www.w3.org/2005/08/addressing', $result[2]->namespace);
@@ -303,24 +304,24 @@ xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-u
             $this->assertInstanceOf('\SoapHeader', $tmp);
         }
 
-        $this->assertInternalType('string', $result[0]->data);
+        $this->assertIsString($result[0]->data);
         $this->assertTrue($this->isValidGuid($result[0]->data));
         $this->assertEquals('MessageID', $result[0]->name);
         $this->assertEquals('http://www.w3.org/2005/08/addressing', $result[0]->namespace);
 
-        $this->assertInternalType('string', $result[1]->data);
+        $this->assertIsString($result[1]->data);
         $this->assertEquals('http://webservices.amadeus.com/PNRRET_11_3_1A', $result[1]->data);
         $this->assertEquals('Action', $result[1]->name);
         $this->assertEquals('http://www.w3.org/2005/08/addressing', $result[1]->namespace);
 
-        $this->assertInternalType('string', $result[2]->data);
+        $this->assertIsString($result[2]->data);
         $this->assertEquals('https://dummy.webservices.endpoint.com/SOAPADDRESS', $result[2]->data);
         $this->assertEquals('To', $result[2]->name);
         $this->assertEquals('http://www.w3.org/2005/08/addressing', $result[2]->namespace);
 
 
         $this->assertInstanceOf('Amadeus\Client\Struct\HeaderV4\TransactionFlowLink', $result[3]->data);
-        $this->assertInternalType('string', $result[3]->data->Consumer->UniqueID);
+        $this->assertIsString($result[3]->data->Consumer->UniqueID);
         $this->assertEquals('TransactionFlowLink', $result[3]->name);
         $this->assertEquals('http://wsdl.amadeus.com/2010/06/ws/Link_v1', $result[3]->namespace);
 
@@ -573,7 +574,7 @@ xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-u
 
         $actual = $method->invoke($sessionHandler, $xml);
 
-        $this->assertInternalType('array', $actual);
+        $this->assertIsArray($actual);
         $this->assertEquals($expected, $actual);
     }
 
@@ -593,19 +594,15 @@ xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-u
 
         $actual = $method->invoke($sessionHandler, $xml);
 
-        $this->assertInternalType('array', $actual);
+        $this->assertIsArray($actual);
         $this->assertEquals($expected, $actual);
     }
 
     public function testCanSendMessage()
     {
-        $overrideSoapClient = $this->getMock(
-            'Amadeus\Client\SoapClient',
-            ['__getLastRequest', '__getLastResponse', 'PNR_Retrieve'],
-            [],
-            '',
-            false
-        );
+        $overrideSoapClient = $this->getMockBuilder(SoapClient::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $dummyPnrRequest = $this->getTestFile('dummyPnrRequest.txt');
         $dummyPnrReply = $this->getTestFile('sessionheadertestresponse.txt');
@@ -623,7 +620,8 @@ xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-u
 
         $overrideSoapClient
             ->expects($this->any())
-            ->method('PNR_Retrieve')
+            ->method('__call')
+            ->with('PNR_Retrieve')
             ->will($this->returnValue(new \stdClass()));
 
         $sessionHandlerParams = $this->makeSessionHandlerParams($overrideSoapClient);
@@ -650,13 +648,9 @@ xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-u
 
     public function testCanSendMessageInExistingSession()
     {
-        $overrideSoapClient = $this->getMock(
-            'Amadeus\Client\SoapClient',
-            ['__getLastRequest', '__getLastResponse', 'PNR_Retrieve'],
-            [],
-            '',
-            false
-        );
+        $overrideSoapClient = $this->getMockBuilder(SoapClient::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $dummyPnrRequest = $this->getTestFile('dummyPnrRequest.txt');
         $dummyPnrReply = $this->getTestFile('sessionheadertestresponse.txt');
@@ -674,7 +668,8 @@ xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-u
 
         $overrideSoapClient
             ->expects($this->any())
-            ->method('PNR_Retrieve')
+            ->method('__call')
+            ->with('PNR_Retrieve')
             ->will($this->returnValue(new \stdClass()));
 
         $sessionHandlerParams = $this->makeSessionHandlerParams($overrideSoapClient);
@@ -717,13 +712,9 @@ xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-u
 
     public function testCanHandleMessageWithSoapFault()
     {
-        $overrideSoapClient = $this->getMock(
-            'Amadeus\Client\SoapClient',
-            ['__getLastRequest', '__getLastResponse', 'PNR_Retrieve'],
-            [],
-            '',
-            false
-        );
+        $overrideSoapClient = $this->getMockBuilder(SoapClient::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $dummyPnrRequest = $this->getTestFile('dummyPnrRequest.txt');
         $dummyPnrReply = $this->getTestFile('sessionheadertestresponse.txt');
@@ -741,7 +732,8 @@ xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-u
 
         $overrideSoapClient
             ->expects($this->any())
-            ->method('PNR_Retrieve')
+            ->method('__call')
+            ->with('PNR_Retrieve')
             ->will($this->throwException(new \SoapFault("Sender", "284|Application|SECURED PNR")));
 
         $sessionHandlerParams = $this->makeSessionHandlerParams($overrideSoapClient);
@@ -767,19 +759,14 @@ xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-u
 
     public function testCanHandleMessageThrowingNonSoapFaultException()
     {
-        $this->setExpectedException('\Amadeus\Client\Exception');
+        $this->expectException(Client\Exception::class);
 
-        $overrideSoapClient = $this->getMock(
-            'Amadeus\Client\SoapClient',
-            ['__getLastRequest', '__getLastResponse', 'PNR_Retrieve'],
-            [],
-            '',
-            false
-        );
+        $overrideSoapClient = $this->getMockBuilder(SoapClient::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $dummyPnrRequest = $this->getTestFile('dummyPnrRequest.txt');
         $dummyPnrReply = $this->getTestFile('sessionheadertestresponse.txt');
-        //$dummyPnrReplyExtractedMessage = $this->getTestFile('dummyPnrReplyExtractedMessage.txt');
 
         $overrideSoapClient
             ->expects($this->atLeastOnce())
@@ -793,7 +780,8 @@ xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-u
 
         $overrideSoapClient
             ->expects($this->once())
-            ->method('PNR_Retrieve')
+            ->method('__call')
+            ->with('PNR_Retrieve')
             ->will($this->throwException(new \InvalidArgumentException("Something is invalid, don't ask me")));
 
         $sessionHandlerParams = $this->makeSessionHandlerParams($overrideSoapClient);
@@ -812,13 +800,9 @@ xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-u
 
     public function testCanExtractSessionDataAfterCall()
     {
-        $overrideSoapClient = $this->getMock(
-            'Amadeus\Client\SoapClient',
-            ['__getLastRequest', '__getLastResponse', 'PNR_Retrieve'],
-            [],
-            '',
-            false
-        );
+        $overrideSoapClient = $this->getMockBuilder(SoapClient::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $dummyPnrRequest = $this->getTestFile('dummyPnrRequest.txt');
         $overrideSoapClient
@@ -833,7 +817,8 @@ xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-u
 
         $overrideSoapClient
             ->expects($this->any())
-            ->method('PNR_Retrieve')
+            ->method('__call')
+            ->with('PNR_Retrieve')
             ->will($this->returnValue($this->getTestFile('acspnr.xml')));
 
         $sessionHandlerParams = $this->makeSessionHandlerParams($overrideSoapClient);
@@ -879,18 +864,17 @@ xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-u
         $this->assertCount(3, $actual);
         $this->assertEquals(['PNR_Retrieve', 'Security_SignOut', 'Security_Authenticate'], array_keys($actual));
         $this->assertEquals('11.3', $actual['PNR_Retrieve']['version']);
-        $this->assertInternalType('string', $actual['PNR_Retrieve']['wsdl']);
+        $this->assertIsString($actual['PNR_Retrieve']['wsdl']);
         $this->assertEquals('4.1', $actual['Security_SignOut']['version']);
-        $this->assertInternalType('string', $actual['Security_SignOut']['wsdl']);
+        $this->assertIsString($actual['Security_SignOut']['wsdl']);
         $this->assertEquals('6.1', $actual['Security_Authenticate']['version']);
-        $this->assertInternalType('string', $actual['Security_Authenticate']['wsdl']);
+        $this->assertIsString($actual['Security_Authenticate']['wsdl']);
     }
 
     public function testCanHandleInvalidWsdlWhenLoadingMessagesAndVersions()
     {
-        \PHPUnit_Framework_Error_Warning::$enabled = FALSE;
-
-        $this->setExpectedException('\Amadeus\Client\InvalidWsdlFileException', 'could not be loaded');
+        $this->expectException(Client\InvalidWsdlFileException::class);
+        $this->expectExceptionMessage('could not be loaded');
 
         $sessionHandlerParams = $this->makeSessionHandlerParams();
         $sessionHandlerParams->wsdl[] = __DIR__. DIRECTORY_SEPARATOR . 'invalidwsdl.wsdl';
@@ -901,9 +885,8 @@ xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-u
 
     public function testCanHandleInvalidImportWsdlWhenLoadingMessagesAndVersions()
     {
-        \PHPUnit_Framework_Error_Warning::$enabled = FALSE;
-
-        $this->setExpectedException('\Amadeus\Client\InvalidWsdlFileException', 'import could not be loaded');
+        $this->expectException(Client\InvalidWsdlFileException::class);
+        $this->expectExceptionMessage('import could not be loaded');
 
         $sessionHandlerParams = $this->makeSessionHandlerParams();
         $sessionHandlerParams->wsdl[] = __DIR__. DIRECTORY_SEPARATOR . 'testfiles' . DIRECTORY_SEPARATOR . 'mediawsdl'.DIRECTORY_SEPARATOR.'DUMMYWSAP_MediaServer_invalid.wsdl';
@@ -919,15 +902,15 @@ xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-u
 
         $actual = $sessionHandler->getMessagesAndVersions();
 
-        $this->assertInternalType('array', $actual);
+        $this->assertIsArray($actual);
         $this->assertCount(4, $actual);
         $this->assertEquals(['PNR_Retrieve', 'Security_SignOut', 'Security_Authenticate', 'Media_GetMedia'], array_keys($actual));
         $this->assertEquals('11.3', $actual['PNR_Retrieve']['version']);
-        $this->assertInternalType('string', $actual['PNR_Retrieve']['wsdl']);
+        $this->assertIsString($actual['PNR_Retrieve']['wsdl']);
         $this->assertEquals('4.1', $actual['Security_SignOut']['version']);
-        $this->assertInternalType('string', $actual['Security_SignOut']['wsdl']);
+        $this->assertIsString($actual['Security_SignOut']['wsdl']);
         $this->assertEquals('1.000', $actual['Media_GetMedia']['version']);
-        $this->assertInternalType('string', $actual['Media_GetMedia']['wsdl']);
+        $this->assertIsString($actual['Media_GetMedia']['wsdl']);
         $this->assertNotEquals($actual['PNR_Retrieve']['wsdl'], $actual['Media_GetMedia']['wsdl']);
     }
 
@@ -954,13 +937,9 @@ xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-u
 
     public function testCanMakeSessionHandlerWithoutLogger()
     {
-        $overrideSoapClient = $this->getMock(
-            'Amadeus\Client\SoapClient',
-            ['__getLastRequest', '__getLastResponse', 'PNR_Retrieve'],
-            [],
-            '',
-            false
-        );
+        $overrideSoapClient = $this->getMockBuilder(SoapClient::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $dummyPnrRequest = $this->getTestFile('dummyPnrRequest.txt');
         $dummyPnrReply = $this->getTestFile('sessionheadertestresponse.txt');
@@ -978,7 +957,8 @@ xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-u
 
         $overrideSoapClient
             ->expects($this->any())
-            ->method('PNR_Retrieve')
+            ->method('__call')
+            ->with('PNR_Retrieve')
             ->will($this->returnValue(new \stdClass()));
 
         $sessionHandlerParams = $this->makeSessionHandlerParams($overrideSoapClient);
@@ -1034,13 +1014,9 @@ xmlns:oas1="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-u
 
     public function testCanGetLastRequestHeaders()
     {
-        $overrideSoapClient = $this->getMock(
-            'Amadeus\Client\SoapClient',
-            ['__getLastRequest', '__getLastResponse', '__getLastRequestHeaders', '__getLastResponseHeaders', 'PNR_Retrieve'],
-            [],
-            '',
-            false
-        );
+        $overrideSoapClient = $this->getMockBuilder(SoapClient::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $dummyPnrRequest = $this->getTestFile('dummyPnrRequest.txt');
         $dummyPnrReply = $this->getTestFile('sessionheadertestresponse.txt');
@@ -1078,7 +1054,8 @@ EOT;
 
         $overrideSoapClient
             ->expects($this->any())
-            ->method('PNR_Retrieve')
+            ->method('__call')
+            ->with('PNR_Retrieve')
             ->will($this->returnValue(new \stdClass()));
 
         $sessionHandlerParams = $this->makeSessionHandlerParams($overrideSoapClient);
@@ -1103,13 +1080,9 @@ EOT;
 
     public function testCanGetLastResponseHeaders()
     {
-        $overrideSoapClient = $this->getMock(
-            'Amadeus\Client\SoapClient',
-            ['__getLastRequest', '__getLastResponse', '__getLastResponseHeaders', '__getLastRequestHeaders', 'PNR_Retrieve'],
-            [],
-            '',
-            false
-        );
+        $overrideSoapClient = $this->getMockBuilder(SoapClient::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $dummyPnrRequest = $this->getTestFile('dummyPnrRequest.txt');
         $dummyPnrReply = $this->getTestFile('sessionheadertestresponse.txt');
@@ -1141,7 +1114,8 @@ EOT;
 
         $overrideSoapClient
             ->expects($this->any())
-            ->method('PNR_Retrieve')
+            ->method('__call')
+            ->with('PNR_Retrieve')
             ->will($this->returnValue(new \stdClass()));
 
         $sessionHandlerParams = $this->makeSessionHandlerParams($overrideSoapClient);

--- a/tests/Amadeus/Client/Struct/DocRefund/UpdateRefundTest.php
+++ b/tests/Amadeus/Client/Struct/DocRefund/UpdateRefundTest.php
@@ -254,7 +254,7 @@ class UpdateRefundTest extends BaseTestCase
 
         $this->assertEquals(UpdateRefund\DateTimeInformation::OPT_DATE_TICKETED, $msg->dateTimeInformation[1]->businessSemantic);
         $this->assertEquals('22', $msg->dateTimeInformation[1]->dateTime->day);
-        $this->assertEquals('5', $msg->dateTimeInformation[1]->dateTime->month);
+        $this->assertEquals('05', $msg->dateTimeInformation[1]->dateTime->month);
         $this->assertEquals('2003', $msg->dateTimeInformation[1]->dateTime->year);
 
         $this->assertCount(2, $msg->referenceInformation->referenceDetails);

--- a/tests/Amadeus/Client/Struct/Fare/MasterPricerExpertSearchTest.php
+++ b/tests/Amadeus/Client/Struct/Fare/MasterPricerExpertSearchTest.php
@@ -78,7 +78,7 @@ class MasterPricerExpertSearchTest extends BaseTestCase
 
         $message = new MasterPricerExpertSearch($opt);
 
-        $this->assertInternalType('array', $message->itinerary);
+        $this->assertIsArray($message->itinerary);
         $this->assertCount(1, $message->itinerary);
         $this->assertInstanceOf('Amadeus\Client\Struct\Fare\MasterPricer\Itinerary', $message->itinerary[0]);
         $this->assertInstanceOf('Amadeus\Client\Struct\Fare\MasterPricer\TimeDetails', $message->itinerary[0]->timeDetails);
@@ -592,7 +592,7 @@ class MasterPricerExpertSearchTest extends BaseTestCase
 
         $message = new MasterPricerExpertSearch($opt);
 
-        $this->assertInternalType('array', $message->itinerary);
+        $this->assertIsArray($message->itinerary);
         $this->assertEquals(1, count($message->itinerary));
         $this->assertInstanceOf('Amadeus\Client\Struct\Fare\MasterPricer\Itinerary', $message->itinerary[0]);
         $this->assertInstanceOf('Amadeus\Client\Struct\Fare\MasterPricer\TimeDetails', $message->itinerary[0]->timeDetails);
@@ -644,7 +644,7 @@ class MasterPricerExpertSearchTest extends BaseTestCase
 
         $message = new MasterPricerExpertSearch($opt);
 
-        $this->assertInternalType('array', $message->itinerary);
+        $this->assertIsArray($message->itinerary);
         $this->assertEquals(1, count($message->itinerary));
         $this->assertInstanceOf('Amadeus\Client\Struct\Fare\MasterPricer\Itinerary', $message->itinerary[0]);
         $this->assertInstanceOf('Amadeus\Client\Struct\Fare\MasterPricer\TimeDetails', $message->itinerary[0]->timeDetails);
@@ -686,7 +686,7 @@ class MasterPricerExpertSearchTest extends BaseTestCase
 
         $message = new MasterPricerExpertSearch($opt);
 
-        $this->assertInternalType('array', $message->itinerary);
+        $this->assertIsArray($message->itinerary);
         $this->assertEquals(1, count($message->itinerary));
         $this->assertInstanceOf('Amadeus\Client\Struct\Fare\MasterPricer\Itinerary', $message->itinerary[0]);
         $this->assertInstanceOf('Amadeus\Client\Struct\Fare\MasterPricer\TimeDetails', $message->itinerary[0]->timeDetails);
@@ -1556,7 +1556,7 @@ class MasterPricerExpertSearchTest extends BaseTestCase
 
         $this->assertCount(1, $msg->itinerary[0]->flightInfo->companyIdentity);
         $this->assertEquals(CompanyIdentity::QUAL_EXCLUDED, $msg->itinerary[0]->flightInfo->companyIdentity[0]->carrierQualifier);
-        $this->assertInternalType('array', $msg->itinerary[0]->flightInfo->companyIdentity[0]->carrierId);
+        $this->assertIsArray($msg->itinerary[0]->flightInfo->companyIdentity[0]->carrierId);
         $this->assertCount(1, $msg->itinerary[0]->flightInfo->companyIdentity[0]->carrierId);
         $this->assertEquals('AA', $msg->itinerary[0]->flightInfo->companyIdentity[0]->carrierId[0]);
 
@@ -1568,7 +1568,7 @@ class MasterPricerExpertSearchTest extends BaseTestCase
 
         $this->assertCount(1, $msg->itinerary[1]->flightInfo->companyIdentity);
         $this->assertEquals(CompanyIdentity::QUAL_PREFERRED, $msg->itinerary[1]->flightInfo->companyIdentity[0]->carrierQualifier);
-        $this->assertInternalType('array', $msg->itinerary[1]->flightInfo->companyIdentity[0]->carrierId);
+        $this->assertIsArray($msg->itinerary[1]->flightInfo->companyIdentity[0]->carrierId);
         $this->assertCount(1, $msg->itinerary[1]->flightInfo->companyIdentity[0]->carrierId);
         $this->assertEquals('BA', $msg->itinerary[1]->flightInfo->companyIdentity[0]->carrierId[0]);
 
@@ -1632,7 +1632,7 @@ class MasterPricerExpertSearchTest extends BaseTestCase
 
         $this->assertNull($msg->itinerary[0]->flightInfo);
 
-        $this->assertInternalType('array', $msg->itinerary[1]->flightInfo->flightDetail->flightType);
+        $this->assertIsArray($msg->itinerary[1]->flightInfo->flightDetail->flightType);
         $this->assertCount(1, $msg->itinerary[1]->flightInfo->flightDetail->flightType);
         $this->assertEquals(FlightDetail::FLIGHT_TYPE_DIRECT, $msg->itinerary[1]->flightInfo->flightDetail->flightType[0]);
 

--- a/tests/Amadeus/Client/Struct/Fare/MasterPricerTravelBoardSearchTest.php
+++ b/tests/Amadeus/Client/Struct/Fare/MasterPricerTravelBoardSearchTest.php
@@ -79,7 +79,7 @@ class MasterPricerTravelBoardSearchTest extends BaseTestCase
 
         $message = new MasterPricerTravelBoardSearch($opt);
 
-        $this->assertInternalType('array', $message->itinerary);
+        $this->assertIsArray($message->itinerary);
         $this->assertCount(1, $message->itinerary);
         $this->assertInstanceOf('Amadeus\Client\Struct\Fare\MasterPricer\Itinerary', $message->itinerary[0]);
         $this->assertInstanceOf('Amadeus\Client\Struct\Fare\MasterPricer\TimeDetails', $message->itinerary[0]->timeDetails);
@@ -593,7 +593,7 @@ class MasterPricerTravelBoardSearchTest extends BaseTestCase
 
         $message = new MasterPricerTravelBoardSearch($opt);
 
-        $this->assertInternalType('array', $message->itinerary);
+        $this->assertIsArray($message->itinerary);
         $this->assertEquals(1, count($message->itinerary));
         $this->assertInstanceOf('Amadeus\Client\Struct\Fare\MasterPricer\Itinerary', $message->itinerary[0]);
         $this->assertInstanceOf('Amadeus\Client\Struct\Fare\MasterPricer\TimeDetails', $message->itinerary[0]->timeDetails);
@@ -645,7 +645,7 @@ class MasterPricerTravelBoardSearchTest extends BaseTestCase
 
         $message = new MasterPricerTravelBoardSearch($opt);
 
-        $this->assertInternalType('array', $message->itinerary);
+        $this->assertIsArray($message->itinerary);
         $this->assertEquals(1, count($message->itinerary));
         $this->assertInstanceOf('Amadeus\Client\Struct\Fare\MasterPricer\Itinerary', $message->itinerary[0]);
         $this->assertInstanceOf('Amadeus\Client\Struct\Fare\MasterPricer\TimeDetails', $message->itinerary[0]->timeDetails);
@@ -687,7 +687,7 @@ class MasterPricerTravelBoardSearchTest extends BaseTestCase
 
         $message = new MasterPricerTravelBoardSearch($opt);
 
-        $this->assertInternalType('array', $message->itinerary);
+        $this->assertIsArray($message->itinerary);
         $this->assertEquals(1, count($message->itinerary));
         $this->assertInstanceOf('Amadeus\Client\Struct\Fare\MasterPricer\Itinerary', $message->itinerary[0]);
         $this->assertInstanceOf('Amadeus\Client\Struct\Fare\MasterPricer\TimeDetails', $message->itinerary[0]->timeDetails);
@@ -1596,7 +1596,7 @@ class MasterPricerTravelBoardSearchTest extends BaseTestCase
 
         $this->assertCount(1, $msg->itinerary[0]->flightInfo->companyIdentity);
         $this->assertEquals(CompanyIdentity::QUAL_EXCLUDED, $msg->itinerary[0]->flightInfo->companyIdentity[0]->carrierQualifier);
-        $this->assertInternalType('array', $msg->itinerary[0]->flightInfo->companyIdentity[0]->carrierId);
+        $this->assertIsArray($msg->itinerary[0]->flightInfo->companyIdentity[0]->carrierId);
         $this->assertCount(1, $msg->itinerary[0]->flightInfo->companyIdentity[0]->carrierId);
         $this->assertEquals('AA', $msg->itinerary[0]->flightInfo->companyIdentity[0]->carrierId[0]);
 
@@ -1608,7 +1608,7 @@ class MasterPricerTravelBoardSearchTest extends BaseTestCase
 
         $this->assertCount(1, $msg->itinerary[1]->flightInfo->companyIdentity);
         $this->assertEquals(CompanyIdentity::QUAL_PREFERRED, $msg->itinerary[1]->flightInfo->companyIdentity[0]->carrierQualifier);
-        $this->assertInternalType('array', $msg->itinerary[1]->flightInfo->companyIdentity[0]->carrierId);
+        $this->assertIsArray($msg->itinerary[1]->flightInfo->companyIdentity[0]->carrierId);
         $this->assertCount(1, $msg->itinerary[1]->flightInfo->companyIdentity[0]->carrierId);
         $this->assertEquals('BA', $msg->itinerary[1]->flightInfo->companyIdentity[0]->carrierId[0]);
 
@@ -1672,7 +1672,7 @@ class MasterPricerTravelBoardSearchTest extends BaseTestCase
 
         $this->assertNull($msg->itinerary[0]->flightInfo);
 
-        $this->assertInternalType('array', $msg->itinerary[1]->flightInfo->flightDetail->flightType);
+        $this->assertIsArray($msg->itinerary[1]->flightInfo->flightDetail->flightType);
         $this->assertCount(1, $msg->itinerary[1]->flightInfo->flightDetail->flightType);
         $this->assertEquals(FlightDetail::FLIGHT_TYPE_DIRECT, $msg->itinerary[1]->flightInfo->flightDetail->flightType[0]);
 
@@ -1864,7 +1864,7 @@ class MasterPricerTravelBoardSearchTest extends BaseTestCase
 
         $message = new MasterPricerTravelBoardSearch($opt);
 
-        $this->assertInternalType('array', $message->itinerary);
+        $this->assertIsArray($message->itinerary);
         $this->assertCount(1, $message->itinerary);
         $this->assertInstanceOf('Amadeus\Client\Struct\Fare\MasterPricer\Itinerary', $message->itinerary[0]);
         $this->assertInstanceOf('Amadeus\Client\Struct\Fare\MasterPricer\TimeDetails', $message->itinerary[0]->timeDetails);
@@ -1944,7 +1944,7 @@ class MasterPricerTravelBoardSearchTest extends BaseTestCase
         ]);
 
         $message = new MasterPricerTravelBoardSearch($opt);
-        $this->assertInternalType('array', $message->paxReference);
+        $this->assertIsArray($message->paxReference);
 
         $this->assertCount(1, $message->paxReference);
         $this->assertCount(2, $message->paxReference[0]->ptc);

--- a/tests/Amadeus/Client/Struct/Fare/PricePNRWithBookingClass12Test.php
+++ b/tests/Amadeus/Client/Struct/Fare/PricePNRWithBookingClass12Test.php
@@ -41,6 +41,7 @@ use Amadeus\Client\Struct\Fare\PricePnr12\TaxIdentification;
 use Amadeus\Client\Struct\Fare\PricePnr13\CriteriaDetails;
 use Amadeus\Client\Struct\Fare\PricePnr13\TaxData;
 use Amadeus\Client\Struct\Fare\PricePNRWithBookingClass12;
+use Amadeus\Client\Struct\OptionNotSupportedException;
 use Test\Amadeus\BaseTestCase;
 
 /**
@@ -117,10 +118,8 @@ class PricePNRWithBookingClass12Test extends BaseTestCase
 
     public function testCanThrowExceptionWhenDoPricePnrCallWithObFees()
     {
-        $this->setExpectedException(
-            '\Amadeus\Client\Struct\OptionNotSupportedException',
-            'OB Fees option not supported in version 12 or lower'
-        );
+        $this->expectException(OptionNotSupportedException::class);
+        $this->expectExceptionMessage('OB Fees option not supported in version 12 or lower');
 
         $opt = new FarePricePnrWithBookingClassOptions([
             'obFees' => [
@@ -135,10 +134,8 @@ class PricePNRWithBookingClass12Test extends BaseTestCase
 
     public function testCanThrowExceptionWhenDoPricePnrCallWithPricingLogic()
     {
-        $this->setExpectedException(
-            '\Amadeus\Client\Struct\OptionNotSupportedException',
-            'Pricing Logic option not supported in version 12 or lower'
-        );
+        $this->expectException(OptionNotSupportedException::class);
+        $this->expectExceptionMessage('Pricing Logic option not supported in version 12 or lower');
 
         $opt = new FarePricePnrWithBookingClassOptions([
             'pricingLogic' => FarePricePnrWithBookingClassOptions::PRICING_LOGIC_IATA
@@ -149,10 +146,8 @@ class PricePNRWithBookingClass12Test extends BaseTestCase
 
     public function testCanThrowExceptionWhenDoPricePnrCallWithOverrideOptionsWithCriteria()
     {
-        $this->setExpectedException(
-            '\Amadeus\Client\Struct\OptionNotSupportedException',
-            'Override Options With Criteria are not supported in version 12 or lower'
-        );
+        $this->expectException(OptionNotSupportedException::class);
+        $this->expectExceptionMessage('Override Options With Criteria are not supported in version 12 or lower');
 
         $opt = new FarePricePnrWithBookingClassOptions([
             'overrideOptionsWithCriteria' => [

--- a/tests/Amadeus/Client/Struct/Fop/ExtendedPaymentDetailsTest.php
+++ b/tests/Amadeus/Client/Struct/Fop/ExtendedPaymentDetailsTest.php
@@ -64,8 +64,8 @@ class ExtendedPaymentDetailsTest extends BaseTestCase
 
     public function testCanLoadHandleLoadInvalidFormatFormat106()
     {
-
-        $this->setExpectedException('\RuntimeException', "Installments Format 'invalid' is not implemented!");
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("Installments Format 'invalid' is not implemented!");
 
         new ExtendedPaymentDetails(
             new InstallmentsInfo([

--- a/tests/Amadeus/Client/Struct/Offer/ConfirmHotelOfferTest.php
+++ b/tests/Amadeus/Client/Struct/Offer/ConfirmHotelOfferTest.php
@@ -24,6 +24,7 @@ namespace Test\Amadeus\Client\Struct\Offer;
 
 use Amadeus\Client\RequestOptions\Offer\PaymentDetails;
 use Amadeus\Client\RequestOptions\OfferConfirmHotelOptions;
+use Amadeus\Client\Struct\InvalidArgumentException;
 use Amadeus\Client\Struct\Offer\ConfirmHotel;
 use Amadeus\Client\Struct\Offer\PassengerReference;
 use Test\Amadeus\BaseTestCase;
@@ -124,10 +125,8 @@ class ConfirmHotelOfferTest extends BaseTestCase
 
     public function testCanConfirmHotelOfferWithUnsupportedFop()
     {
-        $this->setExpectedException(
-            'Amadeus\Client\Struct\InvalidArgumentException',
-            'Hotel Offer Confirm Form of Payment ADV is not yet supported'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Hotel Offer Confirm Form of Payment ADV is not yet supported');
         $opt = new OfferConfirmHotelOptions([
             'recordLocator' => 'ABC123',
             'offerReference' => 2,

--- a/tests/Amadeus/Client/Struct/Pnr/AddMultiElements/AirAuxItineraryTest.php
+++ b/tests/Amadeus/Client/Struct/Pnr/AddMultiElements/AirAuxItineraryTest.php
@@ -22,8 +22,8 @@
 
 namespace Test\Amadeus\Client\Struct\Pnr\AddMultiElements;
 
-use Amadeus\Client\RequestOptions\Pnr\Segment\Air;
 use Amadeus\Client\RequestOptions\Pnr\Segment\Ghost;
+use Amadeus\Client\Struct\InvalidArgumentException;
 use Amadeus\Client\Struct\Pnr\AddMultiElements\AirAuxItinerary;
 use Test\Amadeus\BaseTestCase;
 
@@ -37,10 +37,8 @@ class AirAuxItineraryTest extends BaseTestCase
 {
     public function testGhostWillThrowException()
     {
-        $this->setExpectedException(
-            '\Amadeus\Client\Struct\InvalidArgumentException',
-            'Segment type Ghost is not supported'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Segment type Ghost is not supported');
 
         $obj = new AirAuxItinerary('Ghost', new Ghost());
     }

--- a/tests/Amadeus/Client/Struct/Pnr/AddMultiElementsTest.php
+++ b/tests/Amadeus/Client/Struct/Pnr/AddMultiElementsTest.php
@@ -49,6 +49,7 @@ use Amadeus\Client\RequestOptions\Pnr\TravellerGroup;
 use Amadeus\Client\RequestOptions\PnrAddMultiElementsOptions;
 use Amadeus\Client\RequestOptions\PnrCreatePnrOptions;
 use Amadeus\Client\RequestOptions\Queue;
+use Amadeus\Client\Struct\InvalidArgumentException;
 use Amadeus\Client\Struct\Pnr\AddMultiElements;
 use Amadeus\Client\Struct\Pnr\AddMultiElements\PnrActions;
 use Test\Amadeus\BaseTestCase;
@@ -97,28 +98,28 @@ class AddMultiElementsTest extends BaseTestCase
         $this->assertCount(1, $requestStruct->pnrActions->optionCode);
         $this->assertEquals(PnrActions::ACTIONOPTION_END_TRANSACT_W_RETRIEVE, $requestStruct->pnrActions->optionCode[0]);
 
-        $this->assertInternalType('array', $requestStruct->travellerInfo);
+        $this->assertIsArray($requestStruct->travellerInfo);
         $this->assertEquals(1, count($requestStruct->travellerInfo));
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\AddMultiElements\TravellerInfo', $requestStruct->travellerInfo[0]);
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\AddMultiElements\ElementManagementPassenger', $requestStruct->travellerInfo[0]->elementManagementPassenger);
         $this->assertEquals(AddMultiElements\ElementManagementPassenger::SEG_NAME, $requestStruct->travellerInfo[0]->elementManagementPassenger->segmentName);
         $this->assertEquals(1, $requestStruct->travellerInfo[0]->elementManagementPassenger->reference->number);
         $this->assertEquals(AddMultiElements\Reference::QUAL_PASSENGER, $requestStruct->travellerInfo[0]->elementManagementPassenger->reference->qualifier);
-        $this->assertInternalType('array', $requestStruct->travellerInfo[0]->passengerData);
+        $this->assertIsArray($requestStruct->travellerInfo[0]->passengerData);
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\AddMultiElements\PassengerData', $requestStruct->travellerInfo[0]->passengerData[0]);
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\AddMultiElements\TravellerInformation', $requestStruct->travellerInfo[0]->passengerData[0]->travellerInformation);
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\AddMultiElements\Traveller', $requestStruct->travellerInfo[0]->passengerData[0]->travellerInformation->traveller);
         $this->assertEquals('Bowie', $requestStruct->travellerInfo[0]->passengerData[0]->travellerInformation->traveller->surname);
-        $this->assertInternalType('array', $requestStruct->travellerInfo[0]->passengerData[0]->travellerInformation->passenger);
+        $this->assertIsArray($requestStruct->travellerInfo[0]->passengerData[0]->travellerInformation->passenger);
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\AddMultiElements\Passenger', $requestStruct->travellerInfo[0]->passengerData[0]->travellerInformation->passenger[0]);
         $this->assertEquals('David', $requestStruct->travellerInfo[0]->passengerData[0]->travellerInformation->passenger[0]->firstName);
         $this->assertEquals(AddMultiElements\Passenger::PASST_ADULT, $requestStruct->travellerInfo[0]->passengerData[0]->travellerInformation->passenger[0]->type);
 
-        $this->assertInternalType('array', $requestStruct->originDestinationDetails);
+        $this->assertIsArray($requestStruct->originDestinationDetails);
         $this->assertEquals(1, count($requestStruct->originDestinationDetails));
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\AddMultiElements\OriginDestinationDetails', $requestStruct->originDestinationDetails[0]);
         $this->assertNull($requestStruct->originDestinationDetails[0]->originDestination);
-        $this->assertInternalType('array', $requestStruct->originDestinationDetails[0]->itineraryInfo);
+        $this->assertIsArray($requestStruct->originDestinationDetails[0]->itineraryInfo);
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\AddMultiElements\ItineraryInfo', $requestStruct->originDestinationDetails[0]->itineraryInfo[0]);
         $this->assertEquals(AddMultiElements\ElementManagementItinerary::SEGMENT_MISCELLANEOUS, $requestStruct->originDestinationDetails[0]->itineraryInfo[0]->elementManagementItinerary->segmentName);
         $this->assertEquals(AddMultiElements\Reference::QUAL_OTHER, $requestStruct->originDestinationDetails[0]->itineraryInfo[0]->elementManagementItinerary->reference->qualifier);
@@ -126,7 +127,7 @@ class AddMultiElementsTest extends BaseTestCase
         $this->assertEquals(AddMultiElements\RelatedProduct::STATUS_CONFIRMED, $requestStruct->originDestinationDetails[0]->itineraryInfo[0]->airAuxItinerary->relatedProduct->status);
 
 
-        $this->assertInternalType('array', $requestStruct->dataElementsMaster->dataElementsIndiv);
+        $this->assertIsArray($requestStruct->dataElementsMaster->dataElementsIndiv);
         $this->assertEquals(3, count($requestStruct->dataElementsMaster->dataElementsIndiv));
         $this->assertEquals('TK', $requestStruct->dataElementsMaster->dataElementsIndiv[0]->elementManagementData->segmentName);
         $this->assertEquals(AddMultiElements\TicketElement::PASSTYPE_PAX, $requestStruct->dataElementsMaster->dataElementsIndiv[0]->ticketElement->passengerType);
@@ -187,7 +188,7 @@ class AddMultiElementsTest extends BaseTestCase
 
         $message = new AddMultiElements($createPnrOptions);
 
-        $this->assertInternalType('array', $message->pnrActions->optionCode);
+        $this->assertIsArray($message->pnrActions->optionCode);
         $this->assertCount(3, $message->pnrActions->optionCode);
         $this->assertEquals(PnrActions::ACTIONOPTION_END_TRANSACT_W_RETRIEVE, $message->pnrActions->optionCode[0]);
         $this->assertEquals(PnrActions::ACTIONOPTION_WARNING_AT_EOT, $message->pnrActions->optionCode[1]);
@@ -211,7 +212,7 @@ class AddMultiElementsTest extends BaseTestCase
         $this->assertEquals('GENERIC TRAVEL REQUEST', $message->originDestinationDetails[0]->itineraryInfo[0]->airAuxItinerary->freetextItinerary->longFreetext);
         $this->assertEquals(AddMultiElements\RelatedProduct::STATUS_CONFIRMED, $message->originDestinationDetails[0]->itineraryInfo[0]->airAuxItinerary->relatedProduct->status);
 
-        $this->assertInternalType('array', $message->dataElementsMaster->dataElementsIndiv);
+        $this->assertIsArray($message->dataElementsMaster->dataElementsIndiv);
         $this->assertCount(3, $message->dataElementsMaster->dataElementsIndiv);
         $this->assertEquals('TK', $message->dataElementsMaster->dataElementsIndiv[0]->elementManagementData->segmentName);
         $this->assertEquals(AddMultiElements\TicketElement::PASSTYPE_PAX, $message->dataElementsMaster->dataElementsIndiv[0]->ticketElement->passengerType);
@@ -278,28 +279,28 @@ class AddMultiElementsTest extends BaseTestCase
         $this->assertCount(1, $requestStruct->pnrActions->optionCode);
         $this->assertEquals(PnrActions::ACTIONOPTION_END_TRANSACT_W_RETRIEVE, $requestStruct->pnrActions->optionCode[0]);
 
-        $this->assertInternalType('array', $requestStruct->travellerInfo);
+        $this->assertIsArray($requestStruct->travellerInfo);
         $this->assertEquals(1, count($requestStruct->travellerInfo));
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\AddMultiElements\TravellerInfo', $requestStruct->travellerInfo[0]);
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\AddMultiElements\ElementManagementPassenger', $requestStruct->travellerInfo[0]->elementManagementPassenger);
         $this->assertEquals(AddMultiElements\ElementManagementPassenger::SEG_NAME, $requestStruct->travellerInfo[0]->elementManagementPassenger->segmentName);
         $this->assertEquals(1, $requestStruct->travellerInfo[0]->elementManagementPassenger->reference->number);
         $this->assertEquals(AddMultiElements\Reference::QUAL_PASSENGER, $requestStruct->travellerInfo[0]->elementManagementPassenger->reference->qualifier);
-        $this->assertInternalType('array', $requestStruct->travellerInfo[0]->passengerData);
+        $this->assertIsArray($requestStruct->travellerInfo[0]->passengerData);
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\AddMultiElements\PassengerData', $requestStruct->travellerInfo[0]->passengerData[0]);
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\AddMultiElements\TravellerInformation', $requestStruct->travellerInfo[0]->passengerData[0]->travellerInformation);
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\AddMultiElements\Traveller', $requestStruct->travellerInfo[0]->passengerData[0]->travellerInformation->traveller);
         $this->assertEquals('Bowie', $requestStruct->travellerInfo[0]->passengerData[0]->travellerInformation->traveller->surname);
-        $this->assertInternalType('array', $requestStruct->travellerInfo[0]->passengerData[0]->travellerInformation->passenger);
+        $this->assertIsArray($requestStruct->travellerInfo[0]->passengerData[0]->travellerInformation->passenger);
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\AddMultiElements\Passenger', $requestStruct->travellerInfo[0]->passengerData[0]->travellerInformation->passenger[0]);
         $this->assertEquals('David', $requestStruct->travellerInfo[0]->passengerData[0]->travellerInformation->passenger[0]->firstName);
         $this->assertEquals(AddMultiElements\Passenger::PASST_ADULT, $requestStruct->travellerInfo[0]->passengerData[0]->travellerInformation->passenger[0]->type);
 
-        $this->assertInternalType('array', $requestStruct->originDestinationDetails);
+        $this->assertIsArray($requestStruct->originDestinationDetails);
         $this->assertEquals(1, count($requestStruct->originDestinationDetails));
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\AddMultiElements\OriginDestinationDetails', $requestStruct->originDestinationDetails[0]);
         $this->assertNull($requestStruct->originDestinationDetails[0]->originDestination);
-        $this->assertInternalType('array', $requestStruct->originDestinationDetails[0]->itineraryInfo);
+        $this->assertIsArray($requestStruct->originDestinationDetails[0]->itineraryInfo);
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\AddMultiElements\ItineraryInfo', $requestStruct->originDestinationDetails[0]->itineraryInfo[0]);
         $this->assertEquals(AddMultiElements\ElementManagementItinerary::SEGMENT_MISCELLANEOUS, $requestStruct->originDestinationDetails[0]->itineraryInfo[0]->elementManagementItinerary->segmentName);
         $this->assertEquals(AddMultiElements\Reference::QUAL_OTHER, $requestStruct->originDestinationDetails[0]->itineraryInfo[0]->elementManagementItinerary->reference->qualifier);
@@ -307,7 +308,7 @@ class AddMultiElementsTest extends BaseTestCase
         $this->assertEquals(AddMultiElements\RelatedProduct::STATUS_CONFIRMED, $requestStruct->originDestinationDetails[0]->itineraryInfo[0]->airAuxItinerary->relatedProduct->status);
 
 
-        $this->assertInternalType('array', $requestStruct->dataElementsMaster->dataElementsIndiv);
+        $this->assertIsArray($requestStruct->dataElementsMaster->dataElementsIndiv);
         $this->assertEquals(4, count($requestStruct->dataElementsMaster->dataElementsIndiv));
         $this->assertEquals('TK', $requestStruct->dataElementsMaster->dataElementsIndiv[0]->elementManagementData->segmentName);
         $this->assertEquals(AddMultiElements\TicketElement::PASSTYPE_PAX, $requestStruct->dataElementsMaster->dataElementsIndiv[0]->ticketElement->passengerType);
@@ -359,7 +360,7 @@ class AddMultiElementsTest extends BaseTestCase
 
         $requestStruct = new AddMultiElements($createPnrOptions);
 
-        $this->assertInternalType('array', $requestStruct->dataElementsMaster->dataElementsIndiv);
+        $this->assertIsArray($requestStruct->dataElementsMaster->dataElementsIndiv);
         $this->assertEquals(2, count($requestStruct->dataElementsMaster->dataElementsIndiv));
 
         $this->assertEquals('FP', $requestStruct->dataElementsMaster->dataElementsIndiv[0]->elementManagementData->segmentName);
@@ -390,7 +391,7 @@ class AddMultiElementsTest extends BaseTestCase
 
         $requestStruct = new AddMultiElements($createPnrOptions);
 
-        $this->assertInternalType('array', $requestStruct->dataElementsMaster->dataElementsIndiv);
+        $this->assertIsArray($requestStruct->dataElementsMaster->dataElementsIndiv);
         $this->assertEquals(2, count($requestStruct->dataElementsMaster->dataElementsIndiv));
 
         $this->assertEquals('FP', $requestStruct->dataElementsMaster->dataElementsIndiv[0]->elementManagementData->segmentName);
@@ -422,7 +423,7 @@ class AddMultiElementsTest extends BaseTestCase
 
         $requestStruct = new AddMultiElements($createPnrOptions);
 
-        $this->assertInternalType('array', $requestStruct->dataElementsMaster->dataElementsIndiv);
+        $this->assertIsArray($requestStruct->dataElementsMaster->dataElementsIndiv);
         $this->assertEquals(2, count($requestStruct->dataElementsMaster->dataElementsIndiv));
 
         $this->assertEquals('FP', $requestStruct->dataElementsMaster->dataElementsIndiv[0]->elementManagementData->segmentName);
@@ -458,7 +459,7 @@ class AddMultiElementsTest extends BaseTestCase
 
         $requestStruct = new AddMultiElements($createPnrOptions);
 
-        $this->assertInternalType('array', $requestStruct->dataElementsMaster->dataElementsIndiv);
+        $this->assertIsArray($requestStruct->dataElementsMaster->dataElementsIndiv);
         $this->assertEquals(2, count($requestStruct->dataElementsMaster->dataElementsIndiv));
 
         $this->assertEquals('FP', $requestStruct->dataElementsMaster->dataElementsIndiv[0]->elementManagementData->segmentName);
@@ -498,7 +499,7 @@ class AddMultiElementsTest extends BaseTestCase
 
         $requestStruct = new AddMultiElements($createPnrOptions);
 
-        $this->assertInternalType('array', $requestStruct->dataElementsMaster->dataElementsIndiv);
+        $this->assertIsArray($requestStruct->dataElementsMaster->dataElementsIndiv);
         $this->assertEquals(2, count($requestStruct->dataElementsMaster->dataElementsIndiv));
 
         $this->assertEquals('FP', $requestStruct->dataElementsMaster->dataElementsIndiv[0]->elementManagementData->segmentName);
@@ -515,7 +516,8 @@ class AddMultiElementsTest extends BaseTestCase
 
     public function testMakePnrWithFormOfPaymentCheckWillThrowException()
     {
-        $this->setExpectedException('\RuntimeException', 'FOP CHECK NOT YET IMPLEMENTED');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('FOP CHECK NOT YET IMPLEMENTED');
         $createPnrOptions = new PnrCreatePnrOptions();
         $createPnrOptions->receivedFrom = "unittest";
         $createPnrOptions->travellers[] = new Traveller([
@@ -1267,11 +1269,11 @@ class AddMultiElementsTest extends BaseTestCase
 
         $requestStruct = new AddMultiElements($options);
 
-        $this->assertInternalType('array', $requestStruct->originDestinationDetails);
+        $this->assertIsArray($requestStruct->originDestinationDetails);
         $this->assertEquals(1, count($requestStruct->originDestinationDetails));
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\AddMultiElements\OriginDestinationDetails', $requestStruct->originDestinationDetails[0]);
         $this->assertNull($requestStruct->originDestinationDetails[0]->originDestination);
-        $this->assertInternalType('array', $requestStruct->originDestinationDetails[0]->itineraryInfo);
+        $this->assertIsArray($requestStruct->originDestinationDetails[0]->itineraryInfo);
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\AddMultiElements\ItineraryInfo', $requestStruct->originDestinationDetails[0]->itineraryInfo[0]);
         $this->assertEquals(AddMultiElements\ElementManagementItinerary::SEGMENT_MISCELLANEOUS, $requestStruct->originDestinationDetails[0]->itineraryInfo[0]->elementManagementItinerary->segmentName);
         $this->assertEquals(AddMultiElements\Reference::QUAL_OTHER, $requestStruct->originDestinationDetails[0]->itineraryInfo[0]->elementManagementItinerary->reference->qualifier);
@@ -1470,7 +1472,8 @@ class AddMultiElementsTest extends BaseTestCase
 
     public function testCreateGhostSegmentWillThrowException()
     {
-        $this->setExpectedException('\RuntimeException', 'NOT YET IMPLEMENTED');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('NOT YET IMPLEMENTED');
 
         $createPnrOptions = new PnrCreatePnrOptions();
         $createPnrOptions->receivedFrom = "unittest";
@@ -1488,10 +1491,8 @@ class AddMultiElementsTest extends BaseTestCase
 
     public function testCreateHotelSegmentWillThrowException()
     {
-        $this->setExpectedException(
-            'Amadeus\Client\Struct\InvalidArgumentException',
-            'Segment type Hotel is not supported'
-        );
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Segment type Hotel is not supported');
 
         $createPnrOptions = new PnrCreatePnrOptions();
         $createPnrOptions->receivedFrom = "unittest";
@@ -1509,10 +1510,8 @@ class AddMultiElementsTest extends BaseTestCase
 
     public function testCreateUnsupportedElementWillThrowException()
     {
-        $this->setExpectedException(
-            'Amadeus\Client\Struct\InvalidArgumentException',
-            'Element type UnsupportedElement is not supported'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Element type UnsupportedElement is not supported');
 
         $createPnrOptions = new PnrCreatePnrOptions();
         $createPnrOptions->receivedFrom = "unittest";
@@ -1982,7 +1981,7 @@ class AddMultiElementsTest extends BaseTestCase
 
         $requestStruct = new AddMultiElements($createPnrOptions);
 
-        $this->assertInternalType('array', $requestStruct->dataElementsMaster->dataElementsIndiv);
+        $this->assertIsArray($requestStruct->dataElementsMaster->dataElementsIndiv);
         $this->assertEquals(2, count($requestStruct->dataElementsMaster->dataElementsIndiv));
 
         $this->assertEquals('FP', $requestStruct->dataElementsMaster->dataElementsIndiv[0]->elementManagementData->segmentName);
@@ -2075,7 +2074,7 @@ class AddMultiElementsTest extends BaseTestCase
 
         $requestStruct = new AddMultiElements($createPnrOptions);
 
-        $this->assertInternalType('array', $requestStruct->dataElementsMaster->dataElementsIndiv);
+        $this->assertIsArray($requestStruct->dataElementsMaster->dataElementsIndiv);
         $this->assertEquals(2, count($requestStruct->dataElementsMaster->dataElementsIndiv));
 
         $this->assertEquals('FP', $requestStruct->dataElementsMaster->dataElementsIndiv[0]->elementManagementData->segmentName);

--- a/tests/Amadeus/Client/Struct/Pnr/DisplayHistoryTest.php
+++ b/tests/Amadeus/Client/Struct/Pnr/DisplayHistoryTest.php
@@ -106,14 +106,14 @@ class DisplayHistoryTest extends BaseTestCase
 
         $this->assertEquals(DisplayHistory\SelectionDetails::OPT_STANDARD, $message->redundantElements->selectionDetails->option);
 
-        $this->assertInternalType('array', $message->predicate);
+        $this->assertIsArray($message->predicate);
         $this->assertCount(1, $message->predicate);
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\DisplayHistory\Predicate', $message->predicate[0]);
 
         $this->assertEquals(DisplayHistory\PredicateSelectionDetails::OPT_SELECTION_PREDICATE, $message->predicate[0]->predicateDetails->selectionDetails->option);
         $this->assertEquals(DisplayHistory\PredicateSelectionDetails::OPTINF_PREDICATE_TYPE, $message->predicate[0]->predicateDetails->selectionDetails->optionInformation);
 
-        $this->assertInternalType('array', $message->predicate[0]->predicateDetails->otherSelectionDetails);
+        $this->assertIsArray($message->predicate[0]->predicateDetails->otherSelectionDetails);
         $this->assertCount(1, $message->predicate[0]->predicateDetails->otherSelectionDetails);
 
         $this->assertEquals(DisplayHistory\PredicateSelectionDetails::OPT_DISP_ENVELOPES_CONTAINING_RF, $message->predicate[0]->predicateDetails->otherSelectionDetails[0]->option);
@@ -178,7 +178,7 @@ class DisplayHistoryTest extends BaseTestCase
 
         $this->assertEquals('3J6YFG', $message->pnrInfo->reservation->controlNumber);
 
-        $this->assertInternalType('array', $message->predicate);
+        $this->assertIsArray($message->predicate);
         $this->assertCount(2, $message->predicate);
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\DisplayHistory\Predicate', $message->predicate[0]);
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\DisplayHistory\Predicate', $message->predicate[1]);
@@ -186,7 +186,7 @@ class DisplayHistoryTest extends BaseTestCase
         $this->assertEquals(DisplayHistory\PredicateSelectionDetails::OPT_SELECTION_PREDICATE, $message->predicate[0]->predicateDetails->selectionDetails->option);
         $this->assertEquals(DisplayHistory\PredicateSelectionDetails::OPTINF_PREDICATE_TYPE, $message->predicate[0]->predicateDetails->selectionDetails->optionInformation);
         $this->assertEmpty($message->predicate[0]->predicateDetails->otherSelectionDetails);
-        $this->assertInternalType('array', $message->predicate[0]->predicateElementType);
+        $this->assertIsArray($message->predicate[0]->predicateElementType);
         $this->assertCount(1, $message->predicate[0]->predicateElementType);
         $this->assertEquals('AIR', $message->predicate[0]->predicateElementType[0]->segmentName);
         $this->assertNull($message->predicate[0]->predicateElementType[0]->reference);
@@ -195,7 +195,7 @@ class DisplayHistoryTest extends BaseTestCase
 
         $this->assertEquals(DisplayHistory\PredicateSelectionDetails::OPT_FILTER_PREDICATE, $message->predicate[1]->predicateDetails->selectionDetails->option);
         $this->assertEquals(DisplayHistory\PredicateSelectionDetails::OPTINF_MATCH_QUEUE_UPDATES, $message->predicate[1]->predicateDetails->selectionDetails->optionInformation);
-        $this->assertInternalType('array', $message->predicate[1]->predicateDetails->otherSelectionDetails);
+        $this->assertIsArray($message->predicate[1]->predicateDetails->otherSelectionDetails);
         $this->assertCount(1, $message->predicate[1]->predicateDetails->otherSelectionDetails);
 
         $this->assertEquals(DisplayHistory\PredicateSelectionDetails::OPT_MATCH_QUEUE_UPDATE, $message->predicate[1]->predicateDetails->otherSelectionDetails[0]->option);
@@ -229,14 +229,14 @@ class DisplayHistoryTest extends BaseTestCase
 
         $message = new DisplayHistory($opt);
 
-        $this->assertInternalType('array', $message->predicate);
+        $this->assertIsArray($message->predicate);
         $this->assertCount(1, $message->predicate);
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\DisplayHistory\Predicate', $message->predicate[0]);
 
         $this->assertEquals(DisplayHistory\PredicateSelectionDetails::OPT_SELECTION_PREDICATE, $message->predicate[0]->predicateDetails->selectionDetails->option);
         $this->assertEquals(DisplayHistory\PredicateSelectionDetails::OPTINF_PREDICATE_TYPE, $message->predicate[0]->predicateDetails->selectionDetails->optionInformation);
         $this->assertEmpty($message->predicate[0]->predicateDetails->otherSelectionDetails);
-        $this->assertInternalType('array', $message->predicate[0]->predicateElementType);
+        $this->assertIsArray($message->predicate[0]->predicateElementType);
         $this->assertCount(1, $message->predicate[0]->predicateElementType);
         $this->assertEquals('AIR', $message->predicate[0]->predicateElementType[0]->segmentName);
         $this->assertEquals(2, $message->predicate[0]->predicateElementType[0]->reference->number);
@@ -264,7 +264,7 @@ class DisplayHistoryTest extends BaseTestCase
 
         $message = new DisplayHistory($opt);
 
-        $this->assertInternalType('array', $message->predicate);
+        $this->assertIsArray($message->predicate);
 
         $this->assertCount(1, $message->predicate);
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\DisplayHistory\Predicate', $message->predicate[0]);
@@ -322,7 +322,7 @@ class DisplayHistoryTest extends BaseTestCase
 
         $message = new DisplayHistory($opt);
 
-        $this->assertInternalType('array', $message->predicate);
+        $this->assertIsArray($message->predicate);
 
         $this->assertCount(2, $message->predicate);
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\DisplayHistory\Predicate', $message->predicate[0]);
@@ -366,7 +366,7 @@ class DisplayHistoryTest extends BaseTestCase
 
         $message = new DisplayHistory($opt);
 
-        $this->assertInternalType('array', $message->predicate);
+        $this->assertIsArray($message->predicate);
 
         $this->assertCount(1, $message->predicate);
         $this->assertInstanceOf('Amadeus\Client\Struct\Pnr\DisplayHistory\Predicate', $message->predicate[0]);

--- a/tests/Amadeus/Client/Struct/Pnr/NameChangeTest.php
+++ b/tests/Amadeus/Client/Struct/Pnr/NameChangeTest.php
@@ -107,7 +107,7 @@ class NameChangeTest extends BaseTestCase
         $this->assertNull($msg->enhancedPassengerGroup[0]->enhancedPassengerInformation[1]->enhancedTravellerNameInfo->otherPaxNamesDetails[0]->nameType);
         $this->assertNull($msg->enhancedPassengerGroup[0]->enhancedPassengerInformation[1]->enhancedTravellerNameInfo->otherPaxNamesDetails[0]->referenceName);
         $this->assertEquals('2007', $msg->enhancedPassengerGroup[0]->enhancedPassengerInformation[1]->dateOfBirthInEnhancedPaxData->dateTime->year);
-        $this->assertEquals('9', $msg->enhancedPassengerGroup[0]->enhancedPassengerInformation[1]->dateOfBirthInEnhancedPaxData->dateTime->month);
+        $this->assertEquals('09', $msg->enhancedPassengerGroup[0]->enhancedPassengerInformation[1]->dateOfBirthInEnhancedPaxData->dateTime->month);
         $this->assertEquals('15', $msg->enhancedPassengerGroup[0]->enhancedPassengerInformation[1]->dateOfBirthInEnhancedPaxData->dateTime->day);
     }
 
@@ -182,7 +182,7 @@ class NameChangeTest extends BaseTestCase
         $this->assertNull($msg->enhancedPassengerGroup[0]->enhancedPassengerInformation[1]->enhancedTravellerNameInfo->otherPaxNamesDetails[0]->nameType);
         $this->assertNull($msg->enhancedPassengerGroup[0]->enhancedPassengerInformation[1]->enhancedTravellerNameInfo->otherPaxNamesDetails[0]->referenceName);
         $this->assertEquals('2011', $msg->enhancedPassengerGroup[0]->enhancedPassengerInformation[1]->dateOfBirthInEnhancedPaxData->dateTime->year);
-        $this->assertEquals('9', $msg->enhancedPassengerGroup[0]->enhancedPassengerInformation[1]->dateOfBirthInEnhancedPaxData->dateTime->month);
+        $this->assertEquals('09', $msg->enhancedPassengerGroup[0]->enhancedPassengerInformation[1]->dateOfBirthInEnhancedPaxData->dateTime->month);
         $this->assertEquals('15', $msg->enhancedPassengerGroup[0]->enhancedPassengerInformation[1]->dateOfBirthInEnhancedPaxData->dateTime->day);
     }
 

--- a/tests/Amadeus/Client/Struct/Queue/MoveItemTest.php
+++ b/tests/Amadeus/Client/Struct/Queue/MoveItemTest.php
@@ -49,7 +49,7 @@ class MoveItemTest extends BaseTestCase
 
         $this->assertEquals(SelectionDetails::MOVE_OPTION_COPY_QUEUE_REMOVE, $struct->placementOption->selectionDetails->option);
         $this->assertEquals('ABC123', $struct->recordLocator->reservation->controlNumber);
-        $this->assertInternalType('array', $struct->targetDetails);
+        $this->assertIsArray($struct->targetDetails);
         $this->assertEquals(2, count($struct->targetDetails));
         $this->assertInstanceOf('Amadeus\Client\Struct\Queue\TargetDetails', $struct->targetDetails[0]);
         $this->assertEquals('BRUXX000', $struct->targetDetails[0]->targetOffice->originatorDetails->inHouseIdentification1);

--- a/tests/Amadeus/Client/Struct/SalesReports/DisplayDailyOrSummarizedReportTest.php
+++ b/tests/Amadeus/Client/Struct/SalesReports/DisplayDailyOrSummarizedReportTest.php
@@ -64,7 +64,10 @@ class DisplayDailyOrSummarizedReportTest extends BaseTestCase
         $msg = new DisplayDailyOrSummarizedReport($opt);
 
         $expectedSalesReportIdentificationOption = new ItemNumberDetails($number, $type);
-        $this->assertArraySubset([$expectedSalesReportIdentificationOption], $msg->salesReportIdentification->itemNumberDetails);
+        self::assertContainsEquals(
+            $expectedSalesReportIdentificationOption,
+            $msg->salesReportIdentification->itemNumberDetails,
+        );
     }
 
     public function testCanMakeMessageWithCurrency()

--- a/tests/Amadeus/Client/Struct/SalesReports/DisplayNetRemitReportTest.php
+++ b/tests/Amadeus/Client/Struct/SalesReports/DisplayNetRemitReportTest.php
@@ -68,7 +68,10 @@ class DisplayNetRemitReportTest extends BaseTestCase
         $msg = new DisplayNetRemitReport($opt);
 
         $expectedTransactionTypeCodeInfo = new TransactionData($type, $code, $issueIndicator);
-        $this->assertArraySubset([$expectedTransactionTypeCodeInfo], $msg->transactionTypeCodeInfo);
+        self::assertEquals(
+            $expectedTransactionTypeCodeInfo->transactionDetails,
+            $msg->transactionTypeCodeInfo[0]->transactionDetails,
+        );
     }
 
     public function testCanMakeMessageWithDocumentInfo()

--- a/tests/Amadeus/Client/Util/SomewhatRandomGeneratorTest.php
+++ b/tests/Amadeus/Client/Util/SomewhatRandomGeneratorTest.php
@@ -37,7 +37,7 @@ class SomewhatRandomGeneratorTest extends BaseTestCase
     {
         $somewhat = SomewhatRandomGenerator::generateSomewhatRandomString();
 
-        $this->assertInternalType('string', $somewhat);
+        $this->assertIsString($somewhat);
         $this->assertEquals(22, mb_strlen($somewhat));
     }
 
@@ -45,7 +45,7 @@ class SomewhatRandomGeneratorTest extends BaseTestCase
     {
         $somewhat = SomewhatRandomGenerator::generateSomewhatRandomString(10);
 
-        $this->assertInternalType('string', $somewhat);
+        $this->assertIsString($somewhat);
         $this->assertEquals(10, mb_strlen($somewhat));
     }
 }

--- a/tests/Amadeus/ClientTest.php
+++ b/tests/Amadeus/ClientTest.php
@@ -60,9 +60,9 @@ class ClientTest extends BaseTestCase
     public function testCanCreateClientWithOverriddenSessionHandlerRequestCreatorAndResponseHandler()
     {
         $par = new Params([
-            'sessionHandler' => $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock(),
-            'requestCreator' => $this->getMockBuilder('Amadeus\Client\RequestCreator\RequestCreatorInterface')->getMock(),
-            'responseHandler' => $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock()
+            'sessionHandler' => $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface'),
+            'requestCreator' => $this->createMock('Amadeus\Client\RequestCreator\RequestCreatorInterface'),
+            'responseHandler' => $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')
         ]);
 
         $client = new Client($par);
@@ -177,7 +177,7 @@ class ClientTest extends BaseTestCase
             'recordLocator' => 'ABC123'
         ]));
 
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockSessionHandler
             ->expects($this->once())
@@ -189,7 +189,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['PNR_Retrieve' => ['version' => "14.2", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -224,7 +224,7 @@ class ClientTest extends BaseTestCase
 
         $expectedPnrResult = new Client\Struct\Pnr\RetrieveAndDisplay('ABC123');
 
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockSessionHandler
             ->expects($this->once())
@@ -236,7 +236,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['PNR_RetrieveAndDisplay' => ['version' => "14.2", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -301,7 +301,7 @@ class ClientTest extends BaseTestCase
 
         $expectedPnrResult = new Client\Struct\Pnr\AddMultiElements($options);
 
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockSessionHandler
             ->expects($this->once())
@@ -313,7 +313,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['PNR_AddMultiElements' => ['version' => "14.2", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -338,7 +338,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoAddMultiElementsSavePNR()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseObject = new \stdClass();
@@ -368,7 +368,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['PNR_AddMultiElements' => ['version' => "14.2", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -393,7 +393,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoAddMultiElementsSavePNRWithRf()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseObject = new \stdClass();
@@ -429,7 +429,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['PNR_AddMultiElements' => ['version' => "14.2", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -454,7 +454,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoDummyPnrCancelCall()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseObject = new \stdClass();
@@ -480,7 +480,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['PNR_Cancel' => ['version' => "14.2", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -510,7 +510,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoDummyPnrSplit()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseObject = new \stdClass();
@@ -533,7 +533,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['PNR_Split' => ['version' => "14.2", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -560,7 +560,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoDummyPnrDisplayHistoryCall()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseObject = new \stdClass();
@@ -585,7 +585,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['PNR_DisplayHistory' => ['version' => "14.2", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -614,7 +614,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoDummyPnrTransferOwnershipCall()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseObject = new \stdClass();
@@ -640,7 +640,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['PNR_TransferOwnership' => ['version' => "14.2", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -670,7 +670,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendPnrChangeElement()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseObject = new \stdClass();
@@ -696,7 +696,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->willReturn(['PNR_ChangeElement' => ['version' => '17.2', 'wsdl' => 'dc22e4ee']]);
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -725,7 +725,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendPnrNameChange()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseObject = new \stdClass();
@@ -758,7 +758,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['PNR_NameChange' => ['version' => "14.2", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -796,7 +796,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoDummyQueueListCall()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $lastResponse = '<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:awsse="http://xml.amadeus.com/2010/06/Session_v3" xmlns:wsa="http://www.w3.org/2005/08/addressing"><SOAP-ENV:Header><wsa:To>http://www.w3.org/2005/08/addressing/anonymous</wsa:To><wsa:From><wsa:Address>https://dummy.endpoint/ENDPOINT</wsa:Address></wsa:From><wsa:Action>http://webservices.amadeus.com/QDQLRQ_11_1_1A</wsa:Action><wsa:MessageID>urn:uuid:916bb446-a6fc-b8a4-b543-ce4b8ba124e1</wsa:MessageID><wsa:RelatesTo RelationshipType="http://www.w3.org/2005/08/addressing/reply">86653CF8-2017-2F7C-AFC2-BD07B22BD185</wsa:RelatesTo><awsse:Session TransactionStatusCode="End"><awsse:SessionId>SESSIONID</awsse:SessionId><awsse:SequenceNumber>1</awsse:SequenceNumber><awsse:SecurityToken>SECTOKEN</awsse:SecurityToken></awsse:Session></SOAP-ENV:Header><SOAP-ENV:Body><Queue_ListReply xmlns="http://xml.amadeus.com/QDQLRR_11_1_1A"><queueView><agent><originatorDetails><inHouseIdentification1>BRU1AXXXX</inHouseIdentification1></originatorDetails></agent><queueNumber><queueDetails><number>0</number></queueDetails></queueNumber><categoryDetails><subQueueInfoDetails><identificationType>C</identificationType><itemNumber>0</itemNumber></subQueueInfoDetails></categoryDetails><pnrCount><quantityDetails><numberOfUnit>1</numberOfUnit></quantityDetails></pnrCount><pnrCount><quantityDetails><numberOfUnit>1</numberOfUnit></quantityDetails></pnrCount><pnrCount><quantityDetails><numberOfUnit>1</numberOfUnit></quantityDetails></pnrCount><item><paxName><paxDetails><surname>TURBO</surname><type>0</type><quantity>0</quantity></paxDetails></paxName><recLoc><reservation><controlNumber>23TCZS</controlNumber></reservation></recLoc><agent><originatorDetails><inHouseIdentification1>BRU1AXXXX</inHouseIdentification1><inHouseIdentification2>WS</inHouseIdentification2></originatorDetails></agent><pnrdates><timeMode>700</timeMode><dateTime><year>2015</year><month>12</month><day>11</day></dateTime></pnrdates><pnrdates><timeMode>701</timeMode><dateTime><year>2016</year><month>1</month><day>5</day></dateTime></pnrdates><pnrdates><timeMode>711</timeMode><dateTime><year>2015</year><month>12</month><day>11</day><hour>12</hour><minutes>28</minutes></dateTime></pnrdates></item></queueView></Queue_ListReply></SOAP-ENV:Body></SOAP-ENV:Envelope>';
         $messageResult = '<Queue_ListReply xmlns="http://xml.amadeus.com/QDQLRR_11_1_1A"><queueView><agent><originatorDetails><inHouseIdentification1>BRU1AXXXX</inHouseIdentification1></originatorDetails></agent><queueNumber><queueDetails><number>0</number></queueDetails></queueNumber><categoryDetails><subQueueInfoDetails><identificationType>C</identificationType><itemNumber>0</itemNumber></subQueueInfoDetails></categoryDetails><pnrCount><quantityDetails><numberOfUnit>1</numberOfUnit></quantityDetails></pnrCount><pnrCount><quantityDetails><numberOfUnit>1</numberOfUnit></quantityDetails></pnrCount><pnrCount><quantityDetails><numberOfUnit>1</numberOfUnit></quantityDetails></pnrCount><item><paxName><paxDetails><surname>TURBO</surname><type>0</type><quantity>0</quantity></paxDetails></paxName><recLoc><reservation><controlNumber>23TCZS</controlNumber></reservation></recLoc><agent><originatorDetails><inHouseIdentification1>BRU1AXXXX</inHouseIdentification1><inHouseIdentification2>WS</inHouseIdentification2></originatorDetails></agent><pnrdates><timeMode>700</timeMode><dateTime><year>2015</year><month>12</month><day>11</day></dateTime></pnrdates><pnrdates><timeMode>701</timeMode><dateTime><year>2016</year><month>1</month><day>5</day></dateTime></pnrdates><pnrdates><timeMode>711</timeMode><dateTime><year>2015</year><month>12</month><day>11</day><hour>12</hour><minutes>28</minutes></dateTime></pnrdates></item></queueView></Queue_ListReply>';
@@ -829,7 +829,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Queue_List' => ['version' => "11.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -862,7 +862,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoPlacePNRCall()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dumyplacepnrmessage';
@@ -891,7 +891,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Queue_PlacePNR' => ['version' => "11.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -922,7 +922,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoQueueRemoveItemCall()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dumyremoveitemmessage';
@@ -944,7 +944,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Queue_RemoveItem' => ['version' => "11.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -975,7 +975,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoQueueMoveItemCall()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummymoveitemmessage';
@@ -997,7 +997,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Queue_MoveItem' => ['version' => "11.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -1038,7 +1038,7 @@ class ClientTest extends BaseTestCase
 
         $expectedMessageResult = new Client\Struct\Command\Cryptic('DAC BRU');
 
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockSessionHandler
             ->expects($this->once())
@@ -1053,7 +1053,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Command_Cryptic' => ['version' => "5.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -1100,7 +1100,7 @@ class ClientTest extends BaseTestCase
             )
         );
 
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockSessionHandler
             ->expects($this->once())
@@ -1115,7 +1115,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['MiniRule_GetFromRec' => ['version' => "18.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -1169,7 +1169,7 @@ class ClientTest extends BaseTestCase
             )
         );
 
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockSessionHandler
             ->expects($this->once())
@@ -1184,7 +1184,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['MiniRule_GetFromPricingRec' => ['version' => "11.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -1231,7 +1231,7 @@ class ClientTest extends BaseTestCase
             ])
         );
 
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockSessionHandler
             ->expects($this->once())
@@ -1246,7 +1246,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['MiniRule_GetFromPricing' => ['version' => "11.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -1288,7 +1288,7 @@ class ClientTest extends BaseTestCase
             ])
         );
 
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockSessionHandler
             ->expects($this->once())
@@ -1303,7 +1303,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['MiniRule_GetFromETicket' => ['version' => "13.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -1333,7 +1333,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoOfferCreateCall()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = $this->getTestFile('offerCreateOfferReply132.txt');
@@ -1369,7 +1369,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Offer_CreateOffer' => ['version' => "13.2", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -1408,7 +1408,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoOfferVerifyCall()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyofferverifymessage';
@@ -1433,7 +1433,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Offer_VerifyOffer' => ['version' => "11.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -1463,7 +1463,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoOfferConfirmHotelOffer()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyofferconfirmhotelmessage';
@@ -1488,7 +1488,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Offer_ConfirmHotelOffer' => ['version' => "11.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -1516,7 +1516,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoOfferConfirmCarOffer()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyofferconfirmcarmessage';
@@ -1543,7 +1543,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Offer_ConfirmCarOffer' => ['version' => "11.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -1584,7 +1584,7 @@ class ClientTest extends BaseTestCase
             ])
         );
 
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockSessionHandler
             ->expects($this->once())
@@ -1599,7 +1599,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Info_EncodeDecodeCity' => ['version' => "05.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -1642,7 +1642,7 @@ class ClientTest extends BaseTestCase
             ])
         );
 
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockSessionHandler
             ->expects($this->once())
@@ -1657,7 +1657,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['PointOfRef_Search' => ['version' => "02.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -1690,7 +1690,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoTicketCreateTSTFromPricing()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyTicketCreateTSTFromPricingmessage';
@@ -1720,7 +1720,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Ticket_CreateTSTFromPricing' => ['version' => "04.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -1753,7 +1753,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoTicketCreateTSMFromPricing()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyTicketCreateTSMFromPricingmessage';
@@ -1783,7 +1783,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Ticket_CreateTSMFromPricing' => ['version' => "09.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -1816,7 +1816,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoTicketCreateTSMFareElement()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyTicketCreateTSMFareElementmessage';
@@ -1844,7 +1844,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Ticket_CreateTSMFareElement' => ['version' => "10.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -1875,7 +1875,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoTicketDeleteTST()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyTicketDeleteTSTmessage';
@@ -1902,7 +1902,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Ticket_DeleteTST' => ['version' => "04.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -1932,7 +1932,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoTicketDeleteTSMP()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = $this->getTestFile('ticketDeleteTsmpReply81.txt');
@@ -1958,7 +1958,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Ticket_DeleteTSMP' => ['version' => "08.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -1987,7 +1987,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoTicketDisplayTST()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyTicketDisplayTSTmessage';
@@ -2013,7 +2013,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Ticket_DisplayTST' => ['version' => "04.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -2042,7 +2042,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoTicketDisplayTSMP()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyTicketDisplayTSMPmessage';
@@ -2068,7 +2068,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Ticket_DisplayTSMP' => ['version' => "13.2", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -2097,7 +2097,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoTicketRetrieveListOfTSM()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyTicketRetrieveListOfTSMmessage';
@@ -2123,7 +2123,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Ticket_RetrieveListOfTSM' => ['version' => "13.2", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -2150,7 +2150,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoTicketDisplayTSMFareElement()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyTicketDisplayTSMFareElementmessage';
@@ -2176,7 +2176,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Ticket_DisplayTSMFareElement' => ['version' => "13.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -2206,7 +2206,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoTicketCheckEligibility()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyTicketCheckEligibilitymessage';
@@ -2244,7 +2244,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Ticket_CheckEligibility' => ['version' => "15.2", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -2285,7 +2285,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoTicketCreateTASF()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyTicketCreateTASFmessage';
@@ -2318,7 +2318,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Ticket_CreateTASF' => ['version' => "12.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -2354,7 +2354,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoTicketAtcShopperMasterPricerTravelBoardSearch()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyTicketAtcShopperMasterPricerTravelBoardSearchMessage';
@@ -2384,7 +2384,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Ticket_ATCShopperMasterPricerTravelBoardSearch' => ['version' => "13.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -2413,7 +2413,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoTicketAtcShopperMasterPricerCalendar()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyTicketAtcShopperMasterPricerCalendarMessage';
@@ -2447,7 +2447,7 @@ class ClientTest extends BaseTestCase
                 'Ticket_ATCShopperMasterPricerCalendar' => ['version' => '18.2', 'wsdl' => 'dc22e4ee']
             ]);
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -2476,7 +2476,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoTicketRepricePNRWithBookingClass()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyTicketRepricePNRWithBookingClassMessage';
@@ -2539,7 +2539,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Ticket_RepricePNRWithBookingClass' => ['version' => "14.3", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -2601,7 +2601,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoTicketReissueConfirmedPricing()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyTicketReissueConfirmedPricingMessage';
@@ -2631,7 +2631,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Ticket_ReissueConfirmedPricing' => ['version' => "13.2", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -2660,7 +2660,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoTicketCancelDocument()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyTicketCancelDocumentMessage';
@@ -2692,7 +2692,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Ticket_CancelDocument' => ['version' => "11.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -2723,7 +2723,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoTicketProcessEDocDocument()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyTicketProcessEDocMessage';
@@ -2754,7 +2754,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Ticket_ProcessEDoc' => ['version' => "15.2", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -2784,7 +2784,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoTicketProcessETicketDocument()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyTicketProcessETicketMessage';
@@ -2815,7 +2815,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Ticket_ProcessETicket' => ['version' => "15.2", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -2845,7 +2845,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanDoOfferConfirmAirOffer()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyofferconfirmairmessage';
@@ -2870,7 +2870,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Offer_ConfirmAirOffer' => ['version' => "11.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -2899,7 +2899,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendAirSellFromRecommendation()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyairsellfromrecommendationrmessage';
@@ -2942,7 +2942,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Air_SellFromRecommendation' => ['version' => "5.2", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -2988,7 +2988,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendAirRebookAirSegment()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyairrebookairsegmentmessage';
@@ -3051,7 +3051,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Air_RebookAirSegment' => ['version' => "14.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -3117,7 +3117,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendAirFlightInfo()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyairflightinformessage';
@@ -3147,7 +3147,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Air_FlightInfo' => ['version' => "7.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -3180,7 +3180,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendAirRetrieveSeatMap()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = $this->getTestFile('airRetrieveSeatMapReply142.txt');
@@ -3212,7 +3212,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Air_RetrieveSeatMap' => ['version' => "14.2", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -3247,7 +3247,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendAirMultiAvailability()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = $this->getTestFile('AirMultiAvailabilityReply.txt');
@@ -3281,7 +3281,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Air_MultiAvailability' => ['version' => "14.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -3318,7 +3318,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendFareMasterPricerExpertSearch()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = $this->getTestFile('fareMasterPricerExpertSearchReply-12.4.txt');
@@ -3363,7 +3363,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Fare_MasterPricerExpertSearch' => ['version' => "12.3", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
         $mockResponseHandler
             ->expects($this->once())
             ->method('analyzeResponse')
@@ -3410,7 +3410,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendFareMasterPricerTravelBoardSearch()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyfarepricemasterpricertravelboardsearchresponsemessage';
@@ -3455,7 +3455,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Fare_MasterPricerTravelBoardSearch' => ['version' => "12.3", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -3503,7 +3503,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendFareMasterPricerCalendar()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyfarepricemasterpricercalendarresponsemessage';
@@ -3550,7 +3550,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Fare_MasterPricerCalendar' => ['version' => "14.3", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -3600,7 +3600,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendPriceXplorerExtremeSearch()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummypricexplorerextremesearchresponsemessage';
@@ -3631,7 +3631,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['PriceXplorer_ExtremeSearch' => ['version' => "10.3", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -3665,7 +3665,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendSalesReportsDisplayQueryReport()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = $this->getTestFile('SalesReportsDisplayQueryReportReply.txt');
@@ -3693,7 +3693,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['SalesReports_DisplayQueryReport' => ['version' => "12.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -3724,7 +3724,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendSalesReportsDisplayDailyOrSummarizedReport()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = $this->getTestFile('SalesReportsDisplayDailyOrSummarizedReportReply.txt');
@@ -3752,7 +3752,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['SalesReports_DisplayDailyOrSummarizedReport' => ['version' => "12.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -3783,7 +3783,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendSalesReportsDisplayNetRemitReport()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = $this->getTestFile('SalesReportsDisplayNetRemitReportReply.txt');
@@ -3811,7 +3811,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['SalesReports_DisplayNetRemitReport' => ['version' => "12.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -3842,7 +3842,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendTravelOrderRetrieve()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = $this->getTestFile('TravelOrderRetrieveReply.txt');
@@ -3869,7 +3869,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Travel_OrderRetrieve' => ['version' => "1.10", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -3899,7 +3899,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanFareGetFareRules()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyfaregetfarerulesmessage';
@@ -3930,7 +3930,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Fare_GetFareRules' => ['version' => "10.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -3964,7 +3964,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanFareCheckRules()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyfarecheckrulesmessage';
@@ -3990,7 +3990,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Fare_CheckRules' => ['version' => "7.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -4019,7 +4019,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanFareConvertCurrency()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyfareconvertcurrencymessage';
@@ -4048,7 +4048,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Fare_ConvertCurrency' => ['version' => "8.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -4080,7 +4080,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanFarePricePnrWithBookingClassVersion12()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyfarepricepnrwithbookingclassmessage';
@@ -4106,7 +4106,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Fare_PricePNRWithBookingClass' => ['version' => "12.3", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -4135,7 +4135,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanFarePricePnrWithBookingClassVersion14()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = $this->getTestFile('farePricePnrWithBookingClassReply14.txt');
@@ -4182,7 +4182,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanFarePricePnrWithLowerFares14()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = $this->getTestFile('farePricePnrWithLowerFaresReply14.txt');
@@ -4228,7 +4228,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanFarePricePnrWithLowerFaresVersion12()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyfarepricepnrwithlowerfaresv12message';
@@ -4254,7 +4254,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Fare_PricePNRWithLowerFares' => ['version' => "12.4", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -4283,7 +4283,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanFarePricePnrWithLowestFare14()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = $this->getTestFile('farePricePnrWithLowestFareReply14.txt');
@@ -4329,7 +4329,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanFarePricePnrWithLowestFareVersion12()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyfarepricepnrwithlowestfarev12message';
@@ -4355,7 +4355,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Fare_PricePNRWithLowestFare' => ['version' => "12.4", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -4384,7 +4384,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanFareInformativePricingWithoutPnrVersion14()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = $this->getTestFile('fareInformativePricingWithoutPnrReply14.txt');
@@ -4429,7 +4429,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanFareInformativeBestPricingWithoutPnrVersion15()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = $this->getTestFile('fareInformativeBestPricingWithoutPnrReply14.txt');
@@ -4474,7 +4474,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanFarePriceUpsellWithoutPnrVersion18()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = $this->getTestFile('farePriceUpsellWithoutPnrReply18.txt');
@@ -4517,7 +4517,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanFareGetFamilyDescriptionVersion18()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = $this->getTestFile('fareGetFareFamilyDescriptionReply18.txt');
@@ -4559,7 +4559,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendServiceIntegratedPricing()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = $this->getTestFile('serviceIntegratedPricingReply151.txt');
@@ -4604,7 +4604,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendServiceIntegratedCatalogue()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = $this->getTestFile('serviceIntegratedCatalogueReply142.txt');
@@ -4649,7 +4649,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendServiceBookPriceService()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = $this->getTestFile('serviceBookPriceServiceReply.txt');
@@ -4701,7 +4701,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendServiceStandaloneCatalogue()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = $this->getTestFile('serviceStandaloneCatalogueReply.txt');
@@ -4851,7 +4851,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendFopCreateFormOfPayment()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = $this->getTestFile('fopCreateForpOfPaymentReply154.txt');
@@ -4952,7 +4952,7 @@ class ClientTest extends BaseTestCase
 
         $expectedMessageResult = new Client\Struct\Security\SignOut();
 
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockSessionHandler
             ->expects($this->once())
@@ -4967,7 +4967,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Security_SignOut' => ['version' => "4.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -5017,7 +5017,7 @@ class ClientTest extends BaseTestCase
             )
         );
 
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockSessionHandler
             ->expects($this->once())
@@ -5032,7 +5032,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Security_Authenticate' => ['version' => "6.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -5102,13 +5102,7 @@ class ClientTest extends BaseTestCase
             )
         );
 
-        $mockSessionHandler = $this->getMock(
-            'Amadeus\Client\Session\Handler\SoapHeader2',
-            ['Security_Authenticate', 'getLastResponse', 'getMessagesAndVersions', 'sendMessage'],
-            [$sessionHandlerParams],
-            '',
-            true
-        );
+        $mockSessionHandler = $this->createMock(Client\Session\Handler\SoapHeader2::class);
 
         $mockSessionHandler
             ->expects($this->once())
@@ -5123,7 +5117,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Security_Authenticate' => ['version' => "6.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -5149,7 +5143,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSetSessionData()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $dummySessionData = [
             'sessionId' => 'XFHZEKLRZHREJ',
@@ -5179,7 +5173,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanGetSessionInfo()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSession = [
             'sessionId' => '01ZWHV5EMT',
@@ -5208,7 +5202,8 @@ class ClientTest extends BaseTestCase
 
     public function testWillGetErrorOnInvalidSessionHandlerParams()
     {
-        $this->setExpectedException('InvalidArgumentException', 'Invalid parameters');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid parameters');
         $par = new Params();
         $par->requestCreatorParams = new Params\RequestCreatorParams([
             'receivedFrom' => 'some RF string',
@@ -5222,7 +5217,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendDocIssuanceIssueTicket()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummydocissuanceissueticketresponse';
@@ -5248,7 +5243,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['DocIssuance_IssueTicket' => ['version' => "9.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -5277,7 +5272,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendDocIssuanceIssueMiscellaneousDocuments()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummydocissuanceissuemiscdocresponse';
@@ -5303,7 +5298,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['DocIssuance_IssueMiscellaneousDocuments' => ['version' => "15.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -5332,7 +5327,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendDocIssuanceIssueCombined()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummydocissuanceissuecombinedresponse';
@@ -5363,7 +5358,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['DocIssuance_IssueCombined' => ['version' => "15.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -5397,7 +5392,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendDocRefundInitRefund()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummydocrefundinitrefundresponse';
@@ -5426,7 +5421,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['DocRefund_InitRefund' => ['version' => "14.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -5458,7 +5453,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendDocRefundIgnoreRefund()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummydocrefundignorerefundresponse';
@@ -5482,7 +5477,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['DocRefund_IgnoreRefund' => ['version' => "14.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -5509,7 +5504,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendDocRefundUpdateRefund()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummydocrefundupdaterefundresponse';
@@ -5713,7 +5708,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['DocRefund_UpdateRefund' => ['version' => "14.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -5920,7 +5915,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendDocRefundProcessRefund()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummydocrefundprocessrefundresponse';
@@ -5946,7 +5941,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['DocRefund_ProcessRefund' => ['version' => "13.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -5975,7 +5970,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendFopValidateFop()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyfopvalidatefopresponse';
@@ -6006,7 +6001,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['FOP_ValidateFOP' => ['version' => "13.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -6040,7 +6035,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendTicketInitRefund()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyticketinitrefundresponse';
@@ -6064,7 +6059,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Ticket_InitRefund' => ['version' => "14.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -6091,7 +6086,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendTicketUpdateRefund()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyTicketUpdateRefundResponse';
@@ -6117,8 +6112,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->willReturn(['Ticket_UpdateRefund' => ['version' => '3.0', 'wsdl' => 'dc22e4ee']]);
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')
-            ->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -6147,7 +6141,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendTicketIgnoreRefund()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyticketignorerefundresponse';
@@ -6171,7 +6165,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Ticket_IgnoreRefund' => ['version' => "14.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -6198,7 +6192,7 @@ class ClientTest extends BaseTestCase
 
     public function testCanSendTicketProcessRefund()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseXml = 'dummyticketprocessrefundresponse';
@@ -6222,7 +6216,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['Ticket_ProcessRefund' => ['version' => "14.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -6252,7 +6246,7 @@ class ClientTest extends BaseTestCase
      */
     public function testCanSendAnyMessageRequestNoResponseXml()
     {
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockedSendResult = new Client\Session\Handler\SendResult();
         $mockedSendResult->responseObject = new \stdClass();
@@ -6286,7 +6280,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['DocIssuance_IssueCombined' => ['version' => "15.1", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -6339,7 +6333,7 @@ class ClientTest extends BaseTestCase
 
         $expectedPnrResult = new Client\Struct\Pnr\Ignore($options);
 
-        $mockSessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $mockSessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
 
         $mockSessionHandler
             ->expects($this->once())
@@ -6351,7 +6345,7 @@ class ClientTest extends BaseTestCase
             ->method('getMessagesAndVersions')
             ->will($this->returnValue(['PNR_Ignore' => ['version' => "14.2", 'wsdl' => 'dc22e4ee']]));
 
-        $mockResponseHandler = $this->getMockBuilder('Amadeus\Client\ResponseHandler\ResponseHandlerInterface')->getMock();
+        $mockResponseHandler = $this->createMock('Amadeus\Client\ResponseHandler\ResponseHandlerInterface');
 
         $mockResponseHandler
             ->expects($this->once())
@@ -6452,7 +6446,7 @@ class ClientTest extends BaseTestCase
     protected function makeClientWithMockedSessionHandler()
     {
         $par = new Params();
-        $par->sessionHandler = $this->getMockBuilder('Amadeus\Client\Session\Handler\HandlerInterface')->getMock();
+        $par->sessionHandler = $this->createMock('Amadeus\Client\Session\Handler\HandlerInterface');
         $par->requestCreatorParams = new Params\RequestCreatorParams([
             'receivedFrom' => 'some RF string',
             'originatorOfficeId' => 'BRUXXXXXX'


### PR DESCRIPTION
As per https://github.com/amabnl/amadeus-ws-client/issues/480 I'm creating this PR to lock the library to PHP 8.
Updated PHPUnit dependency to ^9.6

Not sure what is situation with CI right now (probably not working).

Min version in `composer.json` is 8.1, but I tested on 8.3.
Fixed all unit tests to be compatible with PHP 8.1+ and newer version of PHPUnit:

```
amadeus-ws-client % git branch
  master
* master-php8
amadeus-ws-client % ./vendor/bin/phpunit
PHPUnit 9.6.21 by Sebastian Bergmann and contributors.

...............................................................  63 / 842 (  7%)
............................................................... 126 / 842 ( 14%)
..................................................WW.WW........ 189 / 842 ( 22%)
............................................................... 252 / 842 ( 29%)
............................................................... 315 / 842 ( 37%)
............................................................... 378 / 842 ( 44%)
............................................................... 441 / 842 ( 52%)
............................................................... 504 / 842 ( 59%)
............................................................... 567 / 842 ( 67%)
............................................................... 630 / 842 ( 74%)
............................................................... 693 / 842 ( 82%)
............................................................... 756 / 842 ( 89%)
............................................................... 819 / 842 ( 97%)
.......................                                         842 / 842 (100%)

Time: 00:00.262, Memory: 28.00 MB

There were 4 warnings:

1) Test\Amadeus\Client\Session\Handler\SoapHeader4Test::testCanCreateSoapHeadersForStatelessCall
assertEqualXMLStructure() is deprecated and will be removed in PHPUnit 10.

2) Test\Amadeus\Client\Session\Handler\SoapHeader4Test::testCanCreateSoapHeadersForStatefullCallAuth
assertEqualXMLStructure() is deprecated and will be removed in PHPUnit 10.

3) Test\Amadeus\Client\Session\Handler\SoapHeader4Test::testCanMakeSoapHeadersWithTransactionFlowLink
assertEqualXMLStructure() is deprecated and will be removed in PHPUnit 10.

4) Test\Amadeus\Client\Session\Handler\SoapHeader4Test::testCanMakeSoapHeadersWithTransactionFlowLinkGeneratedGuid
assertEqualXMLStructure() is deprecated and will be removed in PHPUnit 10.

WARNINGS!
Tests: 842, Assertions: 7319, Warnings: 4.
```

There is no new alternative of `assertEqualXMLStructure` (seems they decided to [just remove this method without replacement](https://github.com/sebastianbergmann/phpunit/issues/4091), it just [stayed a draft](https://github.com/sebastianbergmann/phpunit/pull/4507)), but it should be ok for now.

---
My live application was using this library under PHP 8.3 long enough, didn't know any issues.
Checked under this branch air booking flow and ticketing.