### PR TITLE
Fix SoapHeader4::generateGuid() has mt_srand() argument always equal 0 after https://github.com/amabnl/amadeus-ws-client/pull/449

### DIFF
--- a/src/Amadeus/Client/Session/Handler/SoapHeader4.php
+++ b/src/Amadeus/Client/Session/Handler/SoapHeader4.php
@@ -420,8 +420,8 @@ class SoapHeader4 extends Base
      */
     protected function generateGuid()
     {
-        mt_srand((int) microtime() * 10000);
-        $charId = strtoupper(md5(uniqid(rand(), true)));
+        mt_srand((int)microtime(true));
+        $charId = strtoupper(md5(uniqid(mt_rand(), true)));
         $hyphen = chr(45); // "-"
 
         $uuid = substr($charId, 0, 8) . $hyphen


### PR DESCRIPTION
So, after fix from https://github.com/amabnl/amadeus-ws-client/pull/449
The argument passed to `mt_srand`: `(int) microtime() * 10000` is always equal 0:

<img width="611" alt="image" src="https://github.com/user-attachments/assets/9d0c2348-d03b-4ab7-a993-4dbc868d1baa">

That's because when cast `microtime()` string to `(int)` it gives 0:
```php
> (int) microtime()
= 0
```
