### PR TITLE
Fixes fatal error on declaration of Amadeus\Client\SoapClient::__doRequest is not compatible with the PHP 8.5 Soap client

### DIFF
--- a/src/Amadeus/Client/SoapClient.php
+++ b/src/Amadeus/Client/SoapClient.php
@@ -66,14 +66,13 @@ class SoapClient extends \SoapClient implements Log\LoggerAwareInterface
      * @param string $location The URL to request.
      * @param string $action The SOAP action.
      * @param int $version The SOAP version.
-     * @param int|null $oneWay
+     * @param bool $oneWay
      * @param string|null $uriParserClass
-     * @uses parent::__doRequest
-     * @return string The XML SOAP response.
+     * @return ?string The XML SOAP response.
      * @throws Exception When PHP XSL extension is not enabled or WSDL file isn't readable.
      */
     #[\ReturnTypeWillChange]
-    public function __doRequest($request, $location, $action, $version, $oneWay = null, $uriParserClass = null)
+    public function __doRequest(string $request, string $location, string $action, int $version, bool $oneWay = false, ?string $uriParserClass = null): ?string
     {
         if (!extension_loaded('xsl')) {
             throw new Exception('PHP XSL extension is not enabled.');

--- a/src/Amadeus/Client/SoapClient.php
+++ b/src/Amadeus/Client/SoapClient.php
@@ -72,8 +72,14 @@ class SoapClient extends \SoapClient implements Log\LoggerAwareInterface
      * @throws Exception When PHP XSL extension is not enabled or WSDL file isn't readable.
      */
     #[\ReturnTypeWillChange]
-    public function __doRequest(string $request, string $location, string $action, int $version, bool $oneWay = false, ?string $uriParserClass = null): ?string
-    {
+    public function __doRequest(
+        string $request,
+        string $location,
+        string $action,
+        int $version,
+        bool $oneWay = false,
+        ?string $uriParserClass = null,
+    ): ?string {
         if (!extension_loaded('xsl')) {
             throw new Exception('PHP XSL extension is not enabled.');
         }


### PR DESCRIPTION
Fixes the fatal error on 

```
Declaration of Amadeus\Client\SoapClient::__doRequest($request, $location, $action, $version, $oneWay = null) must be compatible with SoapClient::__doRequest(string $request, string $location, string $action, int $version, bool $oneWay = false, ?string_$uriParserClass_=+null):+?string=
```

Ran tests using `php_version=8.5 make test`